### PR TITLE
fix return type for string.split()

### DIFF
--- a/JavaScript/index.d.ts
+++ b/JavaScript/index.d.ts
@@ -1083,7 +1083,7 @@ interface String {
 	 * @param delimiter Specifies the string to use for delimiting. If delimiter is omitted, the array returned contains one element, consisting of the entire string.
 	 * @param limit 
 	 */
-	split(delimiter: string, limit: number): string;
+	split(delimiter: string, limit: number): string[];
 
 	/**
 	 * Returns a string consisting of this string enclosed in a <strike> tag.


### PR DESCRIPTION
Hi, fix return type for string.split(),  "string" to "string[]".
thanks.