### PR TITLE
Document.path is a Folder

### DIFF
--- a/Photoshop/2015.5/index.d.ts
+++ b/Photoshop/2015.5/index.d.ts
@@ -8322,7 +8322,7 @@ declare class Document {
 	/**
 	 * The path to the document.
 	 */
-	readonly path: File;
+	readonly path: Folder;
 
 	/**
 	 * The path items collection in this document.


### PR DESCRIPTION
Adobe documentation has app.activeDocument.path (Document.path) as a File type when it is actually a Folder type. This can be verified by:

`app.activeDocument.path instanceof Folder`

<img width="655" alt="screen shot 2017-11-09 at 7 06 53 pm" src="https://user-images.githubusercontent.com/6440325/32621812-47069312-c581-11e7-8f9d-17b8a102cec7.png">

