### PR TITLE
Adding AfterEffects CC2018 types

### DIFF
--- a/AfterEffects/2018/index.d.ts
+++ b/AfterEffects/2018/index.d.ts
@@ -1,0 +1,2486 @@
+/// <reference path="../../global/index.d.ts" />
+
+// CONSTANTS
+
+declare const enum AppVersion {
+  CS3 = 8.0,
+  CS4 = 9.0,
+  CS5 = 10.0,
+  CS5_5 = 10.5,
+  CS6 = 11.0,
+  CC = 12.0,
+  CC2014 = 13.0,
+  CC2015 = 13.5,
+  CC2015_1 = 13.6,
+  CC2015_2 = 13.7,
+  CC2015_3 = 13.8,
+  CC2017 = 14.0,
+}
+
+declare const enum CommandID {
+  /*
+  * File
+  */
+  NewProject = 2,
+  NewFolder = 2139,
+  NewAdobePhotoshopFile = 3147,
+  NewMAXONCINEMA4DFile = 4007,
+  OpenProject = 3,
+  OpenRecentProject1 = 2330,
+  OpenRecentProject2 = 2331,
+  OpenRecentProject3 = 2332,
+  OpenRecentProject4 = 2333,
+  OpenRecentProject5 = 2334,
+  BrowseInBridge = 3689,
+
+  Close = 4,
+  CloseProject = 3154,
+  Save = 5,
+  SaveAs = 6,
+  SaveACopy = 2166,
+  SaveACopyAsXML = 3785,
+  IncrementAndSave = 3088,
+  Revert = 7,
+
+  ImportFile = 2003,
+  ImportMultipleFiles = 2236,
+  ImportPlaceholder = 2126,
+  ImportSolid = 3000,
+  ImportRecentFootage1 = 2310,
+  ImportRecentFootage2 = 2311,
+  ImportRecentFootage3 = 2312,
+  ImportRecentFootage4 = 2313,
+  ImportRecentFootage5 = 2314,
+  ImportRecentFootage6 = 2315,
+  ImportRecentFootage7 = 2316,
+  ImportRecentFootage8 = 2317,
+  ImportRecentFootage9 = 2318,
+  ImportRecentFootage10 = 2319,
+  ExportAddToAdobeMediaEncoderQueue = 3800,
+  ExportAddToRenderQueue = 2161,
+
+  AddFootageToComp = 2005,
+  NewCompFromSelection = 2796,
+
+  CollectFiles = 2482,
+  ConsolidateAllFootage = 2107,
+  RemoveUnsedFootage = 2109,
+  ReduceProject = 2735,
+  FindMissingEffects = 4002,
+  FindMissingFonts = 4003,
+  FindMissingFootage = 4004,
+  WatchFolder = 2457,
+
+  RunScriptFile = 8000,
+  OpenScriptEditor = 8001,
+
+  CreateProxyStill = 2778,
+  CreateProxyMovie = 2779,
+  SetProxyFile = 2003,
+  SetProxyNone = 2119,
+  InterpretFootageMain = 2077,
+  InterpretFootageProxy = 2103,
+  InterpretFootageRememberInterpretation = 2254,
+  InterpretFootageApplyInterpretation = 2255,
+  ReplaceFootageFile = 2003,
+  ReplaceFootageWithLayeredComp = 3070,
+  ReplaceFootagePlaceholder = 2126,
+  ReplaceFootageSolid = 3000,
+  ReloadFootage = 2257,
+  RevealInExploler = 2562,
+  RevealInFinder = 2562,
+  RevealInBridge = 3690,
+
+  ProjectSettings = 2611,
+
+  /*
+  * Edit
+  */
+  Undo = 16,
+  Redo = 17,
+
+  Cut = 18,
+  Copy = 19,
+  CopyWithPropertyLinks = 10310,
+  CopyExpressionOnly = 53,
+  Paste = 20,
+  Clear = 21,
+
+  Duplicate = 2080,
+  SplitLayer = 2158,
+  LiftWorkArea = 2613,
+  ExtractWorkArea = 2614,
+  SelectAll = 23,
+  DeselectAll = 2004,
+
+  PurgeAllMemoryAndDiskCache = 10200,
+  PurgeAllMemory = 2373,
+  PurgeUndo = 2371,
+  PurgeImageCacheMemory = 2372,
+  PurgeSnapshot = 2481,
+
+  EditOriginal = 2142,
+  EditInAdobeAudition = 3697,
+
+  TemplatesRenderSettings = 2149,
+  TemplatesOutputModule = 2150,
+  PasteMochaMask = 5006,
+
+  /*
+  * Composition
+  */
+  NewComposition = 2000,
+
+  CompositionSettings = 2007,
+  SetPosterTime = 2012,
+  TrimCompToWorkArea = 2360,
+  CropCompToRegionOfInterest = 2997,
+  AddToAdobeMediaEncoderQueue = 3800,
+  AddToRenderQueue = 2161,
+  AddOutputModule = 2154,
+
+  SaveFrameAs = 2233,
+  SaveFrameAsPhotoshopLayers = 5001,
+  PreRender = 2780,
+
+  CompositionFlowchart = 2258,
+  CompositionMiniFlowchart = 3792,
+
+  /*
+  * Layer
+  */
+  NewText = 2836,
+  NewSolid = 2038,
+  NewLight = 2563,
+  NewCamera = 2564,
+  NewNullObject = 2767,
+  NewShapeLayer = 3736,
+  NewAdjustmentLayer = 2279,
+  //NewAdobePhotoshopFile = 3147,
+  //NewMAXONCINEMA4DFile = 4007,
+  LayerSettings = 2021,
+
+  OpenLayer = 3784,
+  OpenLayerSource = 2523,
+  //RevealInExploler = 2562,
+  //RevealInFinder = 2562,
+
+  NewMask = 2367,
+  ResetMask = 2448,
+  RemoveMask = 2368,
+  RemoveAllMasks = 2369,
+  UnlockAllMasks = 2456,
+  LockOtherMasks = 2455,
+  HideLockedMasks = 2524,
+
+  QualityBest = 2045,
+  QualityDraft = 2044,
+  QualityWireframe = 2042,
+  QualityBilinear = 10207,
+  QualityBicubic = 10208,
+
+  HideOtherVideo = 2054,
+  ShowAllVideo = 2055,
+  UnlockAllLayers = 2244,
+
+  FlipHorizontal = 3766,
+  FlipVertical = 3767,
+  CenterInView = 3819,
+  CenterAnchorPointInLayerContent = 10312,
+  FitToComp = 2156,
+  FitToCompWidth = 2732,
+  FitToCompHeight = 2733,
+  EnableTimeRemapping = 2153,
+  TimeReverseLayer = 2135,
+  TimeStretch = 2024,
+  FreezeFrame = 3695,
+  AddMarker = 2157,
+
+  LayerStylesConvertToEditableStyles = 3740,
+  LayerStylesShowAll = 3743,
+  LayerStylesRemoveAll = 2072,
+  LayerStylesDropShadow = 9000,
+  LayerStylesInnerShadow = 9001,
+  LayerStylesOuterGlow = 9002,
+  LayerStylesInnerGlow = 9003,
+  LayerStylesBevelAndEmboss = 9004,
+  LayerStylesSatin = 9005,
+  LayerStylesColorOverlay = 9006,
+  LayerStylesGradientOverlay = 9007,
+  LayerStylesStroke = 9008,
+
+  GroupShapes = 3741,
+  UngroupShapes = 3742,
+
+  ConvertToEditableText = 3799,
+  CreateShapesFromText = 3781,
+  CreateMasksFromText = 2933,
+  CreateShapesFromVectorLayer = 3973,
+  CreateStereo3DRig = 3843,
+  CreateOrbitNull = 3844,
+  LinkFocusDistanceToPointOfInterest = 3845,
+  LinkFocusDistanceToLayer = 3847,
+  SetFocusDitanceToLayer = 3846,
+  AutoTrace = 3044,
+  PreCompose = 2071,
+
+  /*
+  * Animation
+  */
+  SaveAnimationPreset = 3075,
+  ApplyAnimationPreset = 2450,
+  RecentAnimationPreset1 = 2460,
+  RecentAnimationPreset2 = 2461,
+  RecentAnimationPreset3 = 2462,
+  RecentAnimationPreset4 = 2463,
+  RecentAnimationPreset5 = 2464,
+  BrowsePresets = 3691,
+
+  ConvertAudioToKeyframes = 5015,
+  ConvertExpressionToKeyframes = 2639,
+  RPFCameraImport = 5018,
+  SequenceLayers = 5003,
+  TimeReverseKeyframes = 3693,
+
+  RemoveAllTextAnimators = 3058,
+
+  AddExpression = 2702,
+  SeparateDimensions = 3764,
+  TrackCamera = 3983,
+  TrackInMochaAE = 5007,
+  WarpStabilizerVFX = 3986,
+  TrackMotion = 2568,
+  TrackMask = 10311,
+  TrackThisProperty = 2643,
+
+  RevealPropertiesWithKeyframes = 2387,
+  RevealPropertiesWithAnimation = 4011,
+  RevealAllModifiedProperties = 2771,
+
+  /*
+  * View
+  */
+  ZoomIn = 2092,
+  ZoomOut = 2093,
+
+  ResolutionFull = 2048,
+  ResolutionHalf = 2047,
+  ResolutionThird = 2081,
+  ResolutionQuarter = 2046,
+  ResolutionCustom = 2049,
+
+  UseDisplayColorManagement = 3704,
+
+  ShowRulers = 2280,
+
+  ShowGuides = 2274,
+  SnapToGuides = 2286,
+  LockGuides = 2275,
+  ClearGuides = 2276,
+
+  ShowGrid = 2277,
+  SnapToGrid = 2278,
+
+  ShowLayerControls = 2435,
+
+  /*
+  * Window
+  */
+  Align = 5022,
+  Audio = 2029,
+  Brushed = 3014,
+  Character = 3011,
+  EffectsAndPresets = 3718,
+  Info = 2028,
+  MaskInterpolation = 5027,
+  MediaBrowser = 4013,
+  Metadata = 3788,
+  MotionSketch = 5024,
+  Paint = 3045,
+  Paragraph = 3012,
+  Preview = 2031,
+  Progress = 4005,
+  Smoother = 5028,
+  Tools = 2010,
+  Tracker = 5005,
+  Wiggler = 5030,
+}
+
+declare enum Language {
+  ENGLISH,
+  JAPANESE,
+  GERMAN,
+  FRENCH,
+  ITALIAN,
+  SPANISH,
+  KOREAN,
+  CHINESE,
+  RUSSIAN,
+  PORTUGUESE,
+}
+
+declare enum PurgeTarget {
+  /** Purges all data that After Effects has cached to physical memory. */
+  ALL_CACHES,
+  /** Purges all data saved in the undo cache. */
+  UNDO_CACHES,
+  /** Purges all data cached as composition/layer snapshots. */
+  SNAPSHOT_CACHES,
+  /** Purges all saved image data. */
+  IMAGE_CACHES
+}
+
+
+declare enum FrameBlendingType {
+  FRAME_MIX,
+  NO_FRAME_BLEND,
+  PIXEL_MOTION
+}
+
+declare enum BlendingMode {
+  ADD,
+  ALPHA_ADD,
+  CLASSIC_COLOR_BURN,
+  CLASSIC_COLOR_DODGE,
+  CLASSIC_DIFFERENCE,
+  COLOR,
+  COLOR_BURN,
+  COLOR_DODGE,
+  DANCING_DISSOLVE,
+  DARKEN,
+  DARKER_COLOR,
+  DIFFERENCE,
+  DISSOLVE,
+  EXCLUSION,
+  HARD_LIGHT,
+  HARD_MIX,
+  HUE,
+  LIGHTEN,
+  LIGHTER_COLOR,
+  LINEAR_BURN,
+  LINEAR_DODGE,
+  LINEAR_LIGHT,
+  LUMINESCENT_PREMUL,
+  LUMINOSITY,
+  MULTIPLY,
+  NORMAL,
+  OVERLAY,
+  PIN_LIGHT,
+  SATURATION,
+  SCREEN,
+  SILHOUETE_ALPHA,
+  SILHOUETTE_LUMA,
+  SOFT_LIGHT,
+  STENCIL_ALPHA,
+  STENCIL_LUMA,
+  VIVID_LIGHT
+}
+
+declare enum TrackMatteType {
+  ALPHA,
+  ALPHA_INVERTED,
+  LUMA,
+  LUMA_INVERTED,
+  NO_TRACK_MATTE
+}
+
+declare enum LayerQuality {
+  BEST,
+  DRAFT,
+  WIREFRAME
+}
+
+declare enum AutoOrientType {
+  /** Layer faces in the direction of the motion path. */
+  ALONG_PATH,
+  /** Layer always faces the active camera or points at its point of interest. */
+  CAMERA_OR_POINT_OF_INTEREST,
+  /** Each character in a per-character 3D text layer automatically faces the active camera. */
+  CHARACTERS_TOWARD_CAMERA,
+  /** Layer rotates freely, independent of any motion path, point of interest, or other layers. */
+  NO_AUTO_ORIENT
+}
+
+declare enum LayerSamplingQuality {
+  BICUBIC,
+  BILINEAR
+}
+
+declare enum AlphaMode {
+  IGNORE,
+  STRAIGHT,
+  PREMULTIPLIED
+}
+
+declare enum FieldSeparationType {
+  OFF,
+  UPPER_FIELD_FIRST,
+  LOWER_FIELD_FIRST
+}
+
+declare enum PulldownPhase {
+  OFF,
+  SSWWW,
+  SWWWS,
+  SWWWW_24P_ADVANCE,
+  WSSWW,
+  WSWWW_24P_ADVANCE,
+  WWSSW,
+  WWSWW_24P_ADVANCE,
+  WWWSS,
+  WWWSW_24P_ADVANCE,
+  WWWWS_24P_ADVANCE
+}
+
+declare enum PulldownMethod {
+  PULLDOWN_3_2,
+  ADVANCE_24P
+}
+
+declare enum ImportAsType {
+  COMP_CROPPED_LAYERS,
+  FOOTAGE,
+  COMP,
+  PROJECT
+}
+
+declare enum LightType {
+  PARALLEL,
+  SPOT,
+  POINT,
+  AMBIENT
+}
+
+declare enum MaskMode {
+  NONE,
+  ADD,
+  SUBTRACT,
+  INTERSECT,
+  LIGHTEN,
+  DARKEN,
+  DIFFERENCE
+}
+
+declare enum MaskMotionBlur {
+  SAME_AS_LAYER,
+  ON,
+  OFF
+}
+
+declare enum MaskFeatherFalloff {
+  FFO_LINEAR,
+  FFO_SMOOTH
+}
+
+declare enum PostRenderAction {
+  NONE,
+  IMPORT,
+  IMPORT_AND_REPLACE_USAGE,
+  SET_PROXY
+}
+
+declare enum GetSettingsFormat {
+  STRING,
+  STRING_SETTABLE,
+  NUMBER,
+  NUMBER_SETTABLE,
+  SPEC
+}
+
+declare enum TimeDisplayType {
+  FRAMES,
+  TIMECODE
+}
+
+declare enum FootageTimecodeDisplayStartType {
+  FTCS_START_0,
+  FTCS_USE_SOURCE_MEDIA
+}
+
+declare enum FeetFramesFilmType {
+  MM16,
+  MM35
+}
+
+declare enum FramesCountType {
+  FC_START_0,
+  FC_START_1,
+  FC_TIMECODE_CONVERSION
+}
+
+declare enum CloseOptions {
+  /** Close without saving. */
+  DO_NOT_SAVE_CHANGES,
+  /** Prompt for whether to save changes before close. */
+  PROMPT_TO_SAVE_CHANGES,
+  /** Save automatically on close. */
+  SAVE_CHANGES
+}
+
+declare enum PropertyValueType {
+  NO_VALUE,
+  ThreeD_SPATIAL,
+  ThreeD,
+  TwoD_SPATIAL,
+  TwoD,
+  OneD,
+  COLOR,
+  CUSTOM_VALUE,
+  MARKER,
+  LAYER_INDEX,
+  MASK_INDEX,
+  SHAPE,
+  TEXT_DOCUMENT
+}
+
+declare enum KeyframeInterpolationType {
+  LINEAR,
+  BEZIER,
+  HOLD
+}
+
+declare enum PropertyType {
+  PROPERTY,
+  INDEXED_GROUP,
+  NAMED_GROUP
+}
+
+declare enum RQItemStatus {
+  WILL_CONTINUE,
+  NEEDS_OUTPUT,
+  UNQUEUED,
+  QUEUED,
+  RENDERING,
+  USER_STOPPED,
+  ERR_STOPPED,
+  DONE
+}
+
+declare enum LogType {
+  ERRORS_ONLY,
+  ERRORS_AND_SETTINGS,
+  ERRORS_AND_PER_FRAME_INFO
+}
+
+declare enum PREFType {
+  PREF_Type_MACHINE_SPECIFIC,
+  PREF_Type_MACHINE_INDEPENDENT,
+  PREF_Type_MACHINE_INDEPENDENT_RENDER,
+  PREF_Type_MACHINE_INDEPENDENT_OUTPUT,
+  PREF_Type_MACHINE_INDEPENDENT_COMPOSITION,
+  PREF_Type_MACHINE_SPECIFIC_TEXT,
+  PREF_Type_MACHINE_SPECIFIC_PAINT
+}
+
+declare enum ParagraphJustification {
+  LEFT_JUSTIFY,
+  CENTER_JUSTIFY,
+  RIGHT_JUSTIFY,
+  FULL_JUSTIFY_LASTLINE_LEFT,
+  FULL_JUSTIFY_LASTLINE_RIGHT,
+  FULL_JUSTIFY_LASTLINE_CENTER,
+  FULL_JUSTIFY_LASTLINE_FULL,
+  MULTIPLE_JUSTIFICATIONS
+}
+
+declare enum ViewerType {
+  VIEWER_COMPOSITION,
+  VIEWER_LAYER,
+  VIEWER_FOOTAGE
+}
+
+declare enum FastPreviewType {
+  FP_OFF,
+  FP_ADAPTIVE_RESOLUTION,
+  FP_DRAFT,
+  FP_FAST_DRAFT,
+  FP_WIREFRAME
+}
+
+declare enum ChannelType {
+  CHANNEL_RGB,
+  CHANNEL_RED,
+  CHANNEL_GREEN,
+  CHANNEL_BLUE,
+  CHANNEL_ALPHA,
+  CHANNEL_RED_COLORIZE,
+  CHANNEL_GREEN_COLORIZE,
+  CHANNEL_BLUE_COLORIZE,
+  CHANNEL_RGB_STRAIGHT,
+  CHANNEL_ALPHA_OVERLAY,
+  CHANNEL_ALPHA_BOUNDARY,
+}
+
+/** CC2015.3- */
+declare enum GpuAccelType {
+  CUDA,
+  METAL,
+  OPENCL,
+  SOFTWARE,
+}
+
+/** CC2017- */
+declare enum ToolType {
+  Tool_Arrow,
+  Tool_Rotate,
+  Tool_CameraMaya,
+  Tool_CameraOrbit,
+  Tool_CameraTrackXY,
+  Tool_CameraTrackZ,
+  Tool_Paintbrush,
+  Tool_CloneStamp,
+  Tool_Eraser,
+  Tool_Hand,
+  Tool_Magnify,
+  Tool_PanBehind,
+  Tool_Rect,
+  Tool_RoundedRect,
+  Tool_Oval,
+  Tool_Polygon,
+  Tool_Star,
+  Tool_TextH,
+  Tool_TextV,
+  Tool_Pen,
+  Tool_Feather,
+  Tool_PenPlus,
+  Tool_PenMinus,
+  Tool_PenConvert,
+  Tool_Pin,
+  Tool_PinStarch,
+  Tool_PinDepth,
+  Tool_Quickselect,
+  Tool_Hairbrush,
+}
+
+// TYPES
+
+/** Clears text from the Info panel. */
+declare var clearOutput: () => void;
+
+/** Converts string time value to a numeric time value. */
+declare var currentFormatToTime: (formattedTime: string, fps: number, isDuration?: boolean) => number;
+
+/** Converts a numeric time value to a string time value. */
+declare var timeToCurrentFormat: (time: number, fps: number, isDuration?: boolean) => string;
+
+/** Writes text to the Info panel, with no line break added. */
+declare var write: (text: string) => void;
+
+/** Writes text to the Info panel, adding a line break at the end. */
+declare var writeLn: (text: string) => void;
+
+/** When true, the specified object exists. */
+declare var isValid: (obj: Object) => boolean;
+
+/** Provides access to objects and application settings within the After Effects application. The single global object is always available by its name, app. */
+declare class Application {
+  /** The current After Effects project. */
+  readonly project: Project;
+
+  /** The locale (language and region) in which the application is running. */
+  readonly isoLanguage: string;
+
+  /** The version number of the After Effects application. */
+  readonly version: string;
+
+  /** The name of this build of the application. */
+  readonly buildName: string;
+
+  /** The number of this build of the application. */
+  readonly buildNumber: number;
+
+  /** When true, the local application is running in Watch Folder mode. */
+  readonly isWatchFolder: boolean;
+
+  /** When true, the local After Effects application is running as a render engine. */
+  readonly isRenderEngine: boolean;
+
+  /** The language After Effects is running. */
+  readonly language: Language;
+
+  /** Application settings that can be set via scripting. */
+  readonly settings: Settings;
+
+  /** A callback function that is called when an error occurs in the application. */
+  onError: string | null;
+
+	/** A numeric status code used when executing a script
+		externally (that is, from a command line or AppleScript).
+		0 if no error occurred. A positive number indicates an
+		error that occurred while running the script. */
+  exitCode: number;
+
+  /** When true, the application remains open after running a script from the command line on Windows. */
+  exitAfterLaunchAndEval: boolean;
+
+  /** When true, the project is saved if the application closes unexpectedly. */
+  saveProjectOnCrash: boolean;
+
+  /** Memory in use by this application. */
+  readonly memoryInUse: number;
+
+  /** The effects available in the application. */
+  readonly effects: { displayName: string, matchName: string, version: string, category: string }[];
+
+  /** The currently focused or last-focused viewer panel. */
+  readonly activeViewer: Viewer | null;
+
+  // Preferences
+  readonly preferences: Preferences;
+
+  /** CC2017- */
+  availableGPUAccelTypes: GpuAccelType;
+
+  /** Creates a new project in After Effects. */
+  newProject(): Project | null;
+
+  /** Opens a project or an Open Project dialog box. */
+  open(file?: File): Project | null;
+
+  /** Quits the application. */
+  quit(): void;
+
+  /** Starts Watch Folder mode; does not return until Watch Folder mode is turned off. */
+  watchFolder(folder_object_to_watch: Folder): void;
+
+  /** Pauses a current watch-folder process. */
+  pauseWatchFolder(pause: boolean): void;
+
+  /** Ends a current watch-folder process. */
+  endWatchFolder(): void;
+
+  /** Purges a targeted type of cached information(replicates Purge options in the Edit menu). */
+  purge(target: PurgeTarget): void;
+
+  /** Groups the actions that follow it into a single undoable step. */
+  beginUndoGroup(undoString: string): void;
+
+  /** Ends an undo group; needed only when a script contains more than one undo group. */
+  endUndoGroup(): void;
+
+  /** Begins suppression of dialogs in the user interface. */
+  beginSuppressDialogs(): void;
+
+  /** Ends suppression of dialogs in the user interface. */
+  endSuppressDialogs(alert: boolean): void;
+
+  /** Sets memory usage limits as in the Memory & Cache preferences area. */
+  setMemoryUsageLimits(imageCachePercentage: number, maximumMemoryPercentage: number): void;
+
+  /** Sets whether preferences are saved when the application is quit. */
+  setSavePreferencesOnQuit(doSave: boolean): void;
+
+  /** Brings the After Effects main window to the front of the screen. */
+  activate(): void;
+
+  /** Schedules a JavaScript script for delayed execution. */
+  scheduleTask(stringToExecute: string, delay: number, repeat: boolean): number;
+
+  /** Cancels a scheduled task. */
+  cancelTask(taskID: number): void;
+
+  /** Loads a color swatch from an Adobe Swatch Exchange (ASE) file. */
+  parseSwatchFile(file: File): Swatch;
+
+  findMenuCommandId(str: string): number;
+
+  executeCommand(id: number): void;
+
+  /** CC2015- */
+  getenv(name: string): string;
+  setTimeout(func: Function, delay?: number): number;
+  cancelTimeout(id: number): void;
+}
+
+declare class Preferences {
+  deletePref(section: string, key: string, type?: PREFType): void;
+  getPrefAsBool(section: string, key: string, type?: PREFType): boolean;
+  getPrefAsFloat(section: string, key: string, type?: PREFType): number;
+  getPrefAsLong(section: string, key: string, type?: PREFType): number;
+  getPrefAsString(section: string, key: string, type?: PREFType): string;
+  havePref(section: string, key: string, type?: PREFType): boolean;
+  reload(): void;
+  savePrefAsBool(section: string, key: string, value: boolean, type?: PREFType): void;
+  savePrefAsFloat(section: string, key: string, value: number, type?: PREFType): void;
+  savePrefAsLong(section: string, key: string, value: number, type?: PREFType): void;
+  savePrefAsString(section: string, key: string, value: string, type?: PREFType): void;
+  saveToDisk(): void;
+}
+
+/** The AVItem object provides access to attributes and methods of audio/visual files imported into After Effects. */
+declare class AVItem extends Item {
+  /** The name of the object as shown in the Project panel. */
+  name: string;
+
+  /** The width of the item. */
+  width: number;
+
+  /** The height of the item. */
+  height: number;
+
+  /** The pixel aspect ratio of the item. */
+  pixelAspect: number;
+
+  /** The frame rate of the item. */
+  frameRate: number;
+
+  /** The frame duration for the item. */
+  frameDuration: number;
+
+  /** The total duration of the item. */
+  duration: number;
+
+  /** When true, a proxy source is used for this item. */
+  useProxy: boolean;
+
+  /** The FootageItem object used as proxy for the item. */
+  readonly proxySource: FootageSource;
+
+  /** Current time of the item. */
+  time: number;
+
+  /** The CompItem objects that use this item. */
+  readonly usedIn: CompItem[];
+
+  /** When true, the item has a video component. */
+  readonly hasVideo: boolean;
+
+  /** When true, the item has an audio component. */
+  readonly hasAudio: boolean;
+
+  /** When true, the item cannot be found or is a placeholder. */
+  readonly footageMissing: boolean;
+
+  /** Sets a proxy for the item. */
+  setProxy(file: File): void;
+
+  /** Sets a sequence as a proxy for the item. */
+  setProxyWithSequence(file: File, forceAlphabetical: boolean): void;
+
+  /** Sets a solid as a proxy for the item. */
+  setProxyWithSolid(color: [number, number, number], name: string, width: number, height: number, pixelAspect: number): void;
+
+  /** Sets a placeholder as a proxy for the item. */
+  setProxyWithPlaceholder(name: string, width: number, height: number, frameRate: number, duration: number): void;
+
+  /** Removes the proxy for the item. */
+  setProxyToNone(): void;
+}
+
+/** The AVLayer object provides an interface to those layers that contain AVItem objects (composition layers, footage layers, solid layers, text layers, and sound layers). */
+declare class AVLayer extends Layer {
+  /** The source item for this layer. */
+  readonly source: any;
+
+  /** When true, the layer has no expressly set name, but contains a named source. */
+  readonly isNameFromSource: boolean;
+
+  /**  The height of the layer.*/
+  readonly height: number;
+
+  /** The width of the layer. */
+  readonly width: number;
+
+  /** When true, the layer's audio is enabled. */
+  audioEnabled: boolean;
+
+  /** When true, the layer's motion blur is enabled. */
+  motionBlur: boolean;
+
+  /** When true, the layer's effects are active. */
+  effectsActive: boolean;
+
+  /** When true, this is an adjustment layer. */
+  adjustmentLayer: boolean;
+
+  /** When true, this is a guide layer. */
+  guideLayer: boolean;
+
+  /** When true, this is a 3D layer. */
+  threeDLayer: boolean;
+
+  /** When true, 3D is set on a per-character basis in this text layer. */
+  threeDPerChar: boolean;
+
+  /** When true, this is an environment layer. */
+  environmentLayer: boolean;
+
+  /** When true, it is legal to change the value of collapseTransformation. */
+  readonly canSetCollapseTransformation: boolean;
+
+  /** When true, collapse transformation is on. */
+  collapseTransformation: boolean;
+
+  /** When true, frame blending is enabled. */
+  readonly frameBlending: boolean;
+
+  /** The type of frame blending for the layer. */
+  frameBlendingType: FrameBlendingType;
+
+  /** When true, it is legal to change the value of timeRemapEnabled. */
+  readonly canSetTimeRemapEnabled: boolean;
+
+  /** When true, time remapping is enabled on this layer. */
+  timeRemapEnabled: boolean;
+
+  /** When true, the layer contains an audio component. */
+  readonly hasAudio: boolean;
+
+  /** When true, the layer's audio is active at the current time. */
+  readonly audioActive: boolean;
+
+  /** The blending mode of the layer. */
+  blendingMode: BlendingMode;
+
+  /** When true, preserve transparency is enabled. */
+  preserveTransparency: boolean;
+
+  /** if layer has a track matte, specifies the way it is applied. */
+  trackMatteType: TrackMatteType;
+
+  /** When true, this layer is being used as a track matte for the layer below it. */
+  readonly isTrackMatte: boolean;
+
+  /** When true, the layer above is being used as a track matte on this layer. */
+  readonly hasTrackMatte: boolean;
+
+  /** The layer quality setting. */
+  quality: LayerQuality;
+
+  /** The layer sampling quality setting. */
+  samplingQuality: LayerSamplingQuality;
+
+  /** Reports whether this layer's audio is active at a given time. */
+  audioActiveAtTime(time: number): boolean;
+
+  /** Calculates a transformation from a set of points in this layer. */
+  calculateTransformFromPoints(pointTopLeft: [number, number, number], pointTopRight: typeof pointTopLeft, pointBottomRight: typeof pointTopLeft): Object;
+
+  /** Changes the source item for this layer. */
+  replaceSource(newSource: AVItem, fixExpressions: boolean): void;
+
+  /** Retrieves the source rectangle of a layer. */
+  sourceRectAtTime(timeT: number, extents: boolean): { top: number; left: number; width: number; height: number; };
+
+  /** Opens the layer in a Layer panel. */
+  openInViewer(): Viewer | null;
+
+  /** CC 2014.2(13.2)- */
+  sourcePointToComp(point: [number, number]): [number, number];
+
+  /** CC 2014.2(13.2)- */
+  compPointToSource(point: [number, number]): [number, number];
+
+  //Shortcuts
+  readonly timeRemap: Property;
+  readonly mask: PropertyGroup;
+  readonly effect: PropertyGroup;
+  readonly layerStyle: _LayerStyles;
+  readonly geometryOption: _GeometryOptionsGroup;
+  readonly materialOption: _MaterialOptionsGroup;
+  readonly audio: _AudioGroup;
+}
+
+/** The CameraLayer object represents a camera layer within a composition. Create it using the LayerCollection object’s addCamera method */
+declare class CameraLayer extends Layer {
+  //Shortcuts
+  readonly cameraOption: _CameraOptionsGroup;
+}
+
+/** Like an array, a collection associates a set of objects or values as a logical group and provides access to them by index. However, most collection objects are read-only. You do not assign objects to them yourself—their contents update automatically as objects are created or deleted. */
+declare class Collection {
+  /** The number of objects in the collection. */
+  readonly length: number;
+}
+
+/** The CompItem object represents a composition, and allows you to manipulate and get information about it. Access the objects by position index number in a project’s item collection. */
+declare class CompItem extends AVItem {
+  /** The duration of a single frame. */
+  frameDuration: number;
+
+  /** When true, indicates that the composition uses drop-frame timecode. */
+  dropFrame: boolean;
+
+  /** The work area start time. */
+  workAreaStart: number;
+
+  /** The work area duration. */
+  workAreaDuration: number;
+
+  /** The number of layers in the composition. */
+  readonly numLayers: number;
+
+  /** When true, shy layers are visible in the Timeline panel. */
+  hideShyLayers: boolean;
+
+  /** When true, motion blur is enabled for this composition. */
+  motionBlur: boolean;
+
+  /** When true, Draft 3D mode is enabled for the Composition panel. */
+  draft3d: boolean;
+
+  /** When true, time filtering is enabled for this composition. */
+  frameBlending: boolean;
+
+  /** When true, the frame rate of nested compositions is preserved. */
+  preserveNestedFrameRate: boolean;
+
+  /** When true, the resolution of nested compositions is preserved. */
+  preserveNestedResolution: boolean;
+
+  /** The background color of the composition. */
+  bgColor: [number, number, number];
+
+  /** The current active camera layer. */
+  readonly activeCamera: CameraLayer | null;
+
+  /** Changes the display of the start time in the Timeline panel. */
+  displayStartTime: number;
+
+  /** The factor by which the x and y resolution of the Composition panel is downsampled. */
+  resolutionFactor: [number, number];
+
+  /** The camera shutter angle. */
+  shutterAngle: number;
+
+  /** The camera shutter phase. */
+  shutterPhase: number;
+
+  /** The minimum number of motion blur samples per frame for Classic 3D layers, shape layers, and certain effects. */
+  motionBlurSamplesPerFrame: number;
+
+  /** The maximum number of motion blur samples of 2D layer motion. */
+  motionBlurAdaptiveSampleLimit: number;
+
+  /** The layers of the composition. */
+  readonly layers: LayerCollection;
+
+  /** CC 2017(14.0)- The markers of the composition. */
+  readonly markerProperty: Property;
+
+  /** The selected layers of the composition. */
+  readonly selectedLayers: Layer[];
+
+  /** The selected properties of the composition. */
+  readonly selectedProperties: PropertyBase[];
+
+  /** The rendering plug-in module to be used to render this composition. */
+  renderer: string;
+
+  /** The set of available rendering plug-in modules. */
+  readonly renderers: string[];
+
+  /** Creates and returns a duplicate of this composition. */
+  duplicate(): CompItem;
+
+  /** Gets a layer from this composition. */
+  layer(index: number): Layer;
+  layer(otherLayer: Layer, relIndex: number): Layer;
+  layer(name: string): Layer;
+
+  /** Opens the composition in a Composition panel. */
+  openInViewer(): Viewer | null;
+
+  /** Save the specific frame to a png file */
+  saveFrameToPng(time: number, file: File): void;
+}
+
+/** The FileSource object describes footage that comes from a file. */
+declare class FileSource extends FootageSource {
+  /** The file that defines this asset. */
+  readonly file: File;
+
+  /** The file that contains footage missing from this asset. */
+  readonly missingFootagePath: string;
+
+  /** Reloads the asset from the file, if it is a mainSource of a FootageItem. */
+  reload(): void;
+}
+
+/** The FolderItem object corresponds to a folder in your Project panel. It can contain various types of items (footage, compositions, solids) as well as other folders. */
+declare class FolderItem extends Item {
+  /** The contents of this folder. */
+  readonly items: ItemCollection;
+
+  /** The number of items contained in the folder. */
+  readonly numItems: number;
+
+  /** Gets an item from the folder. */
+  item(index: number): Item;
+}
+
+/** The FootageItem object represents a footage item imported into a project, which appears in the Project panel. These are accessed by position index number in a project’s item collection. */
+declare class FootageItem extends AVItem {
+  /** The footage source file. */
+  readonly file: File | null;
+
+  /** All settings related to the footage item. */
+  readonly mainSource: FootageSource;
+
+  /** Replaces a footage file with another footage file. */
+  replace(file: File): void;
+
+  /** Replaces a footage file with a placeholder object. */
+  replaceWithPlaceholder(name: string, width: number, height: number, frameRate: number, duration: number): void;
+
+  /** Replaces a footage file with an image sequence. */
+  replaceWithSequence(file: File, forceAlphabetical: boolean): void;
+
+  /** Replaces a footage file with a solid. */
+  replaceWithSolid(color: [number, number, number], name: string, width: number, height: number, pixelAspect: number): void;
+
+  /** Opens the footage in a Footage panel. */
+  openInViewer(): Viewer | null;
+}
+
+declare class PlaceholderItem extends FootageItem { }
+
+/** The FootageSource object holds information describing the source of some footage. It is used as the mainSource of a FootageItem, or the proxySource of a CompItem or FootageItem. */
+declare class FootageSource {
+  /** When true, a footage clip or proxy includes an alpha channel. */
+  hasAlpha: boolean;
+
+  /** The mode of an alpha channel. */
+  alphaMode: AlphaMode;
+
+  /** The color to be premultiplied. */
+  premulColor: [number, number, number];
+
+  /** When true, an alpha channel in a footage clip or proxy should be inverted. */
+  invertAlpha: boolean;
+
+  /** When true, footage is a still image. */
+  readonly isStill: boolean;
+
+  /** The field separation type. */
+  fieldSeparationType: FieldSeparationType;
+
+  /** How the fields are to be separated in non-still footage. */
+  highQualityFieldSeparation: boolean;
+
+  /** The pulldown type for the footage. */
+  removePulldown: PulldownPhase;
+
+  /** How many times an image sequence is set to loop. */
+  loop: number;
+
+  /** The native frame rate of the footage. */
+  nativeFrameRate: number;
+
+  /** The effective frame rate as displayed and rendered in compositions by After Effects. */
+  readonly displayFrameRate: number;
+
+  /** The rate to which footage should conform. */
+  conformFrameRate: number;
+
+  /** Estimates the alphaMode setting. */
+  guessAlphaMode(): void;
+
+  /** Estimates the pulldownType setting. */
+  guessPulldown(method: PulldownMethod): void;
+}
+
+/** The ImportOptions object encapsulates the options used to import a file with the Project.importFile methods. */
+declare class ImportOptions {
+  constructor(file?: File);
+
+  /** The type of file to be imported. */
+  importAs: ImportAsType;
+
+  /** When true, import a sequence of files, rather than an individual file. */
+  sequence: boolean;
+
+  /** When true, the “Force alphabetical order” option is set. */
+  forceAlphabetical: boolean;
+
+  /** The file to import, or the first file of the sequence to import. */
+  file: File;
+
+  /** Restricts input to a particular file type. */
+  canImportAs(type: ImportAsType): boolean;
+}
+
+/** The Item object represents an item that can appear in the Project panel. */
+declare class Item {
+  /** The name of the object as shown in the Project panel. */
+  name: string;
+
+  /** A descriptive string. */
+  comment: string;
+
+  /** A unique identifier for this item. */
+  readonly id: number;
+
+  /** The parent folder of this item. */
+  parentFolder: FolderItem;
+
+  /** When true, this item is currently selected. */
+  selected: boolean;
+
+  /** The type of item. */
+  readonly typeName: string;
+
+  /** The label color for the item. */
+  label: number;
+
+  /** Deletes the item from the project. */
+  remove(): void;
+}
+
+/** The ItemCollection object represents a collection of items. The ItemCollection belonging to a Project object contains all the Item objects for items in the project. The ItemCollection belonging to a FolderItem object contains all the Item objects for items in that folder. */
+declare class ItemCollection extends Collection {
+  /** Retrieves a Item object in the collection by its index number. The first object is at index 1. */
+  readonly [index: number]: Item;
+
+  /** Creates a new CompItem object and adds it to the collection. */
+  addComp(name: string, width: number, height: number, pixelAspect: number, duration: number, frameRate: number): CompItem;
+
+  /** Creates a new FolderItem object and adds it to the collection. */
+  addFolder(name: string): FolderItem;
+}
+
+/** The KeyframeEase object encapsulates the keyframe ease settings of a layer’s AE property. Keyframe ease is determined by the speed and influence values that you set using the property’s setTemporalEaseAtKey method. */
+declare class KeyframeEase {
+  constructor(speed: number, influence: number);
+
+  /** The speed setting for a keyframe. */
+  speed: number;
+
+  /** The influence setting for a keyframe. */
+  influence: number;
+}
+
+/** The Layer object provides access to layers within compositions. It can be accessed from an item’s layer collection either by index number or by a name string. */
+declare interface Layer {
+  (index: number): PropertyBase;
+  (name: string): PropertyBase;
+}
+
+declare class Layer {
+  /** The index position of the layer. */
+  readonly index: number;
+
+  /** The name of the layer. */
+  name: string;
+
+  /** The parent of this layer. */
+  parent: Layer | null;
+
+  /** The current time of the layer. */
+  readonly time: number;
+
+  /** The start time of the layer. */
+  startTime: number;
+
+  /** The time stretch percentage of the layer. */
+  stretch: number;
+
+  /** The “in” point of the layer. */
+  inPoint: number;
+
+  /** The “out” point of the layer. */
+  outPoint: number;
+
+  /** When true, the layer is enabled. */
+  enabled: boolean;
+
+  /** When true, the layer is soloed. */
+  solo: boolean;
+
+  /** When true, the layer is shy. */
+  shy: boolean;
+
+  /** When true, the layer is locked. */
+  locked: boolean;
+
+  /** When true, the layer contains a video component. */
+  readonly hasVideo: boolean;
+
+  /** When true, the layer is active at the current time. */
+  readonly active: boolean;
+
+  /** When true, this is a null layer. */
+  readonly nullLayer: boolean;
+
+  /** All selected AE properties in the layer. */
+  readonly selectedProperties: PropertyBase[];
+
+  /** A descriptive comment for the layer. */
+  comment: string;
+
+  /** The composition that contains this layer. */
+  readonly containingComp: CompItem;
+
+  /** When true, the layer’s name has been explicitly set. */
+  readonly isNameSet: boolean;
+
+  /** The label color for the layer. */
+  label: number;
+
+  /** The type of automatic orientation for the layer. */
+  autoOrient: AutoOrientType;
+
+  /** Deletes the layer from the composition. */
+  remove(): void;
+
+  /** Moves the layer to the top of the composition (makes it the first layer). */
+  moveToBeginning(): void;
+
+  /** Moves the layer to the bottom of the composition (makes it the last layer). */
+  moveToEnd(): void;
+
+  /** Moves the layer below another layer. */
+  moveAfter(layer: Layer): void;
+
+  /** Moves the layer above another layer. */
+  moveBefore(layer: Layer): void;
+
+  /** Duplicates the layer. */
+  duplicate(): Layer;
+
+  /** Copies the layer to the top (beginning) of another composition. */
+  copyToComp(intoComp: CompItem): void;
+
+  /** Reports whether this layer will be active at a specified time. */
+  activeAtTime(time: number): boolean;
+
+  /** Sets a new parent for this layer. */
+  setParentWithJump(newParent?: Layer): void;
+
+  /** Applies a named collection of animation settings to the layer. */
+  applyPreset(presetName: File): void;
+
+  //From PropertyGroup
+  readonly matchName: string;
+  readonly propertyDepth: number;
+  readonly propertyType: PropertyType;
+  selected: boolean;
+  readonly numProperties: number;
+
+  propertyGroup(countUp?: number): PropertyGroup;
+  property(index: number): PropertyBase;
+  property(name: string): PropertyBase;
+
+  //Shortcuts
+  readonly marker: Property;
+  readonly transform: _TransformGroup;
+}
+
+/** The LayerCollection object represents a set of layers. The LayerCollection belonging to a CompItem object contains all the layer objects for layers in the composition. The methods of the collection object allow you to manipulate the layer list. */
+declare class LayerCollection extends Collection {
+  /** Retrieves a Layer object in the collection by its index number. The first object is at index 1. */
+  readonly [index: number]: Layer;
+
+  /** Creates a new AVLayer and adds it to this collection. */
+  add(item: AVItem, duration?: number): AVLayer;
+
+  /** Creates a new, null layer and adds it to this collection. */
+  addNull(duration?: number): AVLayer;
+
+  /** Creates a new layer, a FootageItem with a SolidSource, and adds it to this collection. */
+  addSolid(color: [number, number, number], name: string, width: number, height: number, pixelAspect: number, duration?: number): AVLayer;
+
+  /** Creates a new point text layer and adds it to this collection. */
+  addText(sourceText?: string | TextDocument): TextLayer;
+
+  /** Creates a new paragraph (box) text layer and adds it to this collection. */
+  addBoxText(size: [number, number], sourceText?: string | TextDocument): TextLayer;
+
+  /** Creates a new camera layer and adds it to this collection. */
+  addCamera(name: string, centerPoint: [number, number]): CameraLayer;
+
+  /** Creates a new light layer and adds it to this collection. */
+  addLight(name: string, centerPoint: [number, number]): LightLayer;
+
+  /** Creates a new shape layer and adds it to this collection. */
+  addShape(): ShapeLayer;
+
+  /** Retrieves the layer object with a specified name. */
+  byName(name: string): Layer | null;
+
+  /** Collects specified layers into a new composition. */
+  precompose(layerIndicies: number[], name: string, moveAllAttributes?: boolean): CompItem;
+}
+
+/** The LightLayer object represents a light layer within a composition. Create it using the LayerCollection object’s addLight method */
+declare class LightLayer extends Layer {
+  /** For light layers, the type of light. */
+  lightType: LightType;
+
+  //Shortcuts
+  readonly lightOption: _LightOptionsGroup;
+}
+
+/** The MarkerValue object represents a layer marker, which associates a comment, and optionally a chapter reference point, Web-page link, or Flash Video cue point with a particular point in a layer. */
+declare class MarkerValue {
+  constructor(comment: string, chapter?: string, url?: string, frameTarget?: string, cuePointName?: string, params?: string);
+
+  /** A comment on the associated layer. */
+  comment: string;
+
+  /** The amount of time represented by the marker. */
+  duration: number;
+
+  /** A chapter link reference point for the associated layer. */
+  chapter: string;
+
+  /** The Flash Video cue point name. */
+  cuePointName: string;
+
+  /** Whether the Flash Video cue point is for an event or navigation. */
+  eventCuePoint: boolean;
+
+  /** A URL for Web page to be associated with the layer. */
+  url: string;
+
+  /** A specific frame target within the Web page specified by url. */
+  frameTarget: string;
+
+  /** Retrieves the key-value pairs associated with the marker value. */
+  getParameters(): Object;
+
+  /** Sets the key-value pairs associated with the marker value. */
+  setParameters(keyValuePairs: Object): void;
+}
+
+/** The MaskPropertyGroup object encapsulates mask attributes in a layer. */
+declare class MaskPropertyGroup extends PropertyGroup {
+  /** The mask mode. */
+  maskMode: MaskMode;
+
+  /** When true, the mask is inverted. */
+  inverted: boolean;
+
+  /** When true, the shape of the mask is RotoBezier. */
+  rotoBezier: boolean;
+
+  /** How motion blur is applied to this mask. */
+  maskMotionBlur: MaskMotionBlur;
+
+  /** When true, the mask is locked. */
+  locked: boolean;
+
+  /** The color used to draw the mask outline in the user interface. */
+  color: [number, number, number];
+
+  /** The feather falloff mode for the mask. */
+  maskFeatherFalloff: MaskFeatherFalloff;
+}
+
+/** The OMCollection contains all of the output modules in a render queue. The collection provides access to the OutputModule objects, but does not provide any additional functionality. The first OutputModule object in the collection is at index position 1. */
+declare class OMCollection extends Collection {
+  /** Retrieves a OutputModule object in the collection by its index number. The first object is at index 1. */
+  readonly [index: number]: OutputModule;
+}
+
+/** An OutputModule object of a RenderQueueItem generates a single file or sequence via a render operation, and contains attributes and methods relating to the file to be rendered. */
+declare class OutputModule {
+  /** The path and name of the file to be rendered. */
+  file: File;
+
+  /** An action to be taken after rendering. */
+  postRenderAction: PostRenderAction;
+
+  /** The user-interface name of the output module. */
+  readonly name: string;
+
+  /** All templates for the output module */
+  readonly templates: string[];
+
+  /** When true, writes all source footage XMP metadata to the output file. */
+  includeSourceXMP: boolean;
+
+  /** Removes this output module from the render-queue item’s list. */
+  remove(): void;
+
+  /** Saves a new output-module template. */
+  saveAsTemplate(name: string): void;
+
+  /** Applies an output-module template. */
+  applyTemplate(templateName: string): void;
+
+  getSetting(key: string): string | number;
+
+  getSettings(format?: GetSettingsFormat): {
+    'Audio Bit Depth': string;
+    'Audio Channels': string;
+    'Audio Sample Rate': string;
+    'Channels': string;
+    'Color': string;
+    'Crop': string;
+    'Crop Bottom': string;
+    'Crop Left': string;
+    'Crop Right': string;
+    'Crop Top': string;
+    'Depth': string;
+    'Format': string;
+    'Include Project Link': string;
+    'Include Source XMP Metadata': string;
+    'Lock Aspect Ratio': string;
+    'Output Audio': string;
+    'Output File Info': string;
+    'Post-Render Action': string;
+    'Resize': string;
+    'Resize Quality': string;
+    'Resize to': object;
+    'Starting #': string;
+    'Use Comp Frame Number': string;
+    'Use Region of Interest': string;
+    'Video Output': string;
+  };
+
+  setSetting(key: string, value: string | number): void;
+
+  setSettings(settings: Object): void;
+}
+
+/** The PlaceholderSource object describes the footage source of a placeholder. */
+declare class PlaceholderSource extends FootageSource { }
+
+/** The project object represents an After Effects project. Attributes provide access to specific objects within the project, such as imported files or footage and compositions, and also to project settings such as the timecode base. Methods can import footage, create solids, compositions and folders, and save changes. */
+declare class Project {
+  /** The file for the currently open project. */
+  readonly file: File | null;
+
+  /** The folder containing all the contents of the project; the equivalent of the Project panel */
+  readonly rootFolder: FolderItem;
+
+  /** All items in the project. */
+  readonly items: ItemCollection;
+
+  /** The currently active item. */
+  readonly activeItem: Item | null;
+
+  /** The color depth of the current project. */
+  bitsPerChannel: number;
+
+  /** When true, thumbnail views use the transparency checkerboard pattern. */
+  transparencyGridThumbnails: boolean;
+
+  /** The total number of items contained in the project. */
+  readonly numItems: number;
+
+  /** All items selected in the Project panel. */
+  readonly selection: Item[];
+
+  /** The project’s render queue. */
+  readonly renderQueue: RenderQueue;
+
+  /** The time display style, corresponding to the Time Display Style section in the Project Settings dialog box. */
+  timeDisplayType: TimeDisplayType;
+
+  /** CC 2017(14.0)- The active tool in the Tools panel. */
+  toolType: ToolType;
+
+  /** The Footage Start Time setting in the Project Settings dialog box, which is enabled when Timecode is selected as the time display style. */
+  footageTimecodeDisplayStartType: FootageTimecodeDisplayStartType;
+
+  /** The Use Feet + Frames setting in the Project Settings dialog box. */
+  framesUseFeetFrames: boolean;
+
+  /** The Use Feet + Frames menu setting in the Project Settings dialog box. */
+  feetFramesFilmType: FeetFramesFilmType;
+
+  /** CC 2015.3(13.8)- */
+  gpuAccelType: GpuAccelType;
+
+  /** The Frame Count menu setting in the Project Settings dialog box. */
+  framesCountType: FramesCountType;
+
+  /** The frame at which to start numbering when displaying the project. */
+  displayStartFrame: number;
+
+  /** When true, linear blending is used for the project. */
+  linearBlending: boolean;
+
+  /** The project’s XMP metadata. */
+  xmpPacket: string;
+
+  /** Retrieves an item from the project. */
+  item(index: number): Item;
+
+  /** Consolidates all footage in the project. */
+  consolidateFootage(): number;
+
+  /** Removes unused footage from the project. */
+  removeUnusedFootage(): number;
+
+  /** Reduces the project to a specified set of items. */
+  reduceProject(array_of_items: Item[]): number;
+
+  /** Closes the project with normal save options. */
+  close(closeOptions: CloseOptions): boolean;
+
+  /** Saves the project. */
+  save(file?: File): void;
+
+  /** Displays a Save dialog box. */
+  saveWithDialog(): boolean;
+
+  /** Imports a placeholder into the project. */
+  importPlaceholder(name: string, width: number, height: number, frameRate: number, duration: number): PlaceholderItem;
+
+  /** Imports a file into the project. */
+  importFile(importOptions: ImportOptions): FootageItem;
+
+  /** Displays an Import File dialog box. */
+  importFileWithDialog(): Item[] | null;
+
+  /** Shows or hides the Project panel. */
+  showWindow(doShow: boolean): void;
+
+  /** Automatically replaces text in all expressions. */
+  autoFixExpressions(oldText: string, newText: string): void;
+}
+
+declare type PropertyValue = void | boolean | number | [number, number] | [number, number, number] | [number, number, number, number] | MarkerValue | Shape | TextDocument;
+
+/** The Property object contains value, keyframe, and expression information about a particular AE property of a layer. */
+declare class Property extends PropertyBase {
+  /** Type of value stored in this property. */
+  readonly propertyValueType: PropertyValueType;
+
+  /** Current value of the property. */
+  readonly value: PropertyValue;
+
+  /** When true, there is a minimum permitted value. */
+  readonly hasMin: boolean;
+
+  /** When true, there is a maximum permitted value. */
+  readonly hasMax: boolean;
+
+  /** The minimum permitted value. */
+  readonly minValue: number;
+
+  /** The maximum permitted value. */
+  readonly maxValue: number;
+
+  /** When true, the property defines a spatial value. */
+  readonly isSpatial: boolean;
+
+  /** When true, the property can be keyframed. */
+  readonly canVaryOverTime: boolean;
+
+  /** When true, the property has keyframes or an expression enabled that can vary its values. */
+  readonly isTimeVarying: boolean;
+
+  /** The number of keyframes on this property. */
+  readonly numKeys: number;
+
+  /** A text description of the units in which the value is expressed. */
+  readonly unitsText: string;
+
+  /** The expression string for this property. */
+  expression: string;
+
+  /** When true, the expression can be set by a script. */
+  readonly canSetExpression: boolean;
+
+  /** When true, the expression is used to generate values for the property. */
+  expressionEnabled: boolean;
+
+  /** The error, if any, that occurred when the last expression was evaluated. */
+  readonly expressionError: string;
+
+  /** All selected keyframes of the property. */
+  readonly selectedKeys: number[];
+
+  /** The position index of this property. */
+  readonly propertyIndex: number;
+
+  /** When true, the property’s dimensions are represented as separate properties. */
+  dimensionsSeparated: boolean;
+
+  /** When true, the property represents one of the separated dimensions for a multidimensional property. */
+  readonly isSeparationFollower: boolean;
+
+  /** When true, the property is multidimensional and can be separated. */
+  readonly isSeparationLeader: boolean;
+
+  /** For a separated follower, the dimension it represents in the multidimensional leader. */
+  readonly separationDimension: number;
+
+  /** The original multidimensional property for this separated follower. */
+  readonly separationLeader: Property;
+
+  /** Gets the value of the property evaluated at given time. */
+  valueAtTime(time: number, preExpression: boolean): PropertyValue;
+
+  /** Sets the static value of the property. */
+  setValue(newValue: PropertyValue): void;
+
+  /** Creates a keyframe for the property. */
+  setValueAtTime(time: number, newValue: PropertyValue): void;
+
+  /** Creates a set of keyframes for the property. */
+  setValuesAtTimes(times: number[], newValues: PropertyValue[]): void;
+
+  /** Finds a keyframe and sets the value of the property at that keyframe. */
+  setValueAtKey(keyIndex: number, newValue: PropertyValue): void;
+
+  /** Gets the keyframe nearest to a specified time. */
+  nearestKeyIndex(time: number): number;
+
+  /** Gets the time at which a condition occurs. */
+  keyTime(keyIndex: number): number;
+  keyTime(markerComment: string): number;
+
+  /** Gets the value of a keyframe at the time at which a condition occurs. */
+  keyValue(keyIndex: number): PropertyValue;
+  keyValue(markerComment: string): MarkerValue;
+
+  /** Adds a new keyframe to the property at a given time. */
+  addKey(time: number): number;
+
+  /** Removes a keyframe from the property. */
+  removeKey(keyIndex: number): void;
+
+  /** When true, this property can be interpolated. */
+  isInterpolationTypeValid(type: KeyframeInterpolationType): boolean;
+
+  /** Sets the interpolation type for a key. */
+  setInterpolationTypeAtKey(keyIndex: number, inType: KeyframeInterpolationType, outType: KeyframeInterpolationType): void;
+
+  /** Gets the 'in' interpolation type for a key. */
+  keyInInterpolationType(keyIndex: number): KeyframeInterpolationType;
+
+  /** Gets the 'out' interpolation type for a key. */
+  keyOutInterpolationType(keyIndex: number): KeyframeInterpolationType;
+
+  /** Sets the “in” and “out” tangent vectors for a key. */
+  setSpatialTangentsAtKey(keyIndex: number, inTangent: [number, number], outTangent: typeof inTangent): void;
+  setSpatialTangentsAtKey(keyIndex: number, inTangent: [number, number, number], outTangent: typeof inTangent): void;
+
+  /** Gets the “in” spatial tangent for a key. */
+  keyInSpatialTangent(keyIndex: number): [number, number] | [number, number, number];
+
+  /** Gets the “out” spatial tangent for a key. */
+  keyOutSpatialTangent(keyIndex: number): [number, number] | [number, number, number];
+
+  /** Sets the “in” and “out” temporal ease for a key. */
+  setTemporalEaseAtKey(keyIndex: number, inTemporalEase: [KeyframeEase], outTemporalEase: typeof inTemporalEase): void;
+  setTemporalEaseAtKey(keyIndex: number, inTemporalEase: [KeyframeEase, KeyframeEase], outTemporalEase: typeof inTemporalEase): void;
+  setTemporalEaseAtKey(keyIndex: number, inTemporalEase: [KeyframeEase, KeyframeEase, KeyframeEase], outTemporalEase: typeof inTemporalEase): void;
+
+  /** Gets the “in” temporal ease for a key. */
+  keyInTemporalEase(keyIndex: number): [KeyframeEase] | [KeyframeEase, KeyframeEase] | [KeyframeEase, KeyframeEase, KeyframeEase];
+
+  /** Gets the “out” temporal ease for a key. */
+  keyOutTemporalEase(keyIndex: number): [KeyframeEase] | [KeyframeEase, KeyframeEase] | [KeyframeEase, KeyframeEase, KeyframeEase];
+
+  /** Sets whether a keyframe has temporal continuity. */
+  setTemporalContinuousAtKey(keyIndex: number, newVal: boolean): void;
+
+  /** Reports whether a keyframe has temporal continuity. */
+  keyTemporalContinuous(keyIndex: number): boolean;
+
+  /** Sets whether a keyframe has temporal auto-Bezier. */
+  setTemporalAutoBezierAtKey(keyIndex: number, newVal: boolean): void;
+
+  /** Reports whether a keyframe has temporal auto-Bezier. */
+  keyTemporalAutoBezier(keyIndex: number): boolean;
+
+  /** Sets whether a keyframe has spatial continuity. */
+  setSpatialContinuousAtKey(keyIndex: number, newVal: boolean): void;
+
+  /** Reports whether a keyframe has spatial continuity. */
+  keySpatialContinuous(keyIndex: number): boolean;
+
+  /** Sets whether a keyframe has spatial auto-Bezier. */
+  setSpatialAutoBezierAtKey(keyIndex: number, newVal: boolean): void;
+
+  /** Reports whether a keyframe has spatial auto-Bezier. */
+  keySpatialAutoBezier(keyIndex: number): boolean;
+
+  /** Sets whether a keyframe is roving. */
+  setRovingAtKey(keyIndex: number, newVal: boolean): void;
+
+  /** Reports whether a keyframe is roving. */
+  keyRoving(keyIndex: number): boolean;
+
+  /** Sets whether a keyframe is selected. */
+  setSelectedAtKey(keyIndex: number, onOff: boolean): void;
+
+  /** Reports whether a keyframe is selected. */
+  keySelected(keyIndex: number): boolean;
+
+  /** For a separated, multidimensional property, retrieves a specific follower property. */
+  getSeparationFollower(dim: number): Property;
+}
+
+/** Properties are accessed by name through layers, using various kinds of expression syntax, as controlled by application preferences. */
+declare interface PropertyBase {
+  (index: number): PropertyBase;
+  (name: string): PropertyBase;
+}
+
+declare class PropertyBase {
+  /** Name of the property. */
+  name: string;
+
+  /** A special name for the property used to build unique naming paths. */
+  readonly matchName: string;
+
+  /** Index of this property within its parent group. */
+  readonly propertyIndex: number;
+
+  /** The number of levels of parent groups between this property and the containing layer. */
+  readonly propertyDepth: number;
+
+  /** The property type. */
+  readonly propertyType: PropertyType;
+
+  /** The immediate parent group of this property. */
+  readonly parentProperty: PropertyGroup;
+
+  /** When true, the property has been changed since its creation. */
+  readonly isModified: boolean;
+
+  /** When true, the user interface displays an eyeball icon for this property. */
+  readonly canSetEnabled: boolean;
+
+  /** When true, this property is enabled. */
+  enabled: boolean;
+
+  /** When true, this property is active. */
+  readonly active: boolean;
+
+  /** When true, this property is not displayed in the user interface. */
+  readonly elided: boolean;
+
+  /** When true, this property is an effect. */
+  readonly isEffect: boolean;
+
+  /** When true, this property is a mask. */
+  readonly isMask: boolean;
+
+  /** When true, this property is selected. */
+  selected: boolean;
+
+  /** Gets the parent group for this property. */
+  propertyGroup(countUp?: number): PropertyGroup;
+
+  /** Removes this from the project. */
+  remove(): void;
+
+  /** Moves this property to a new position in its parent group. */
+  moveTo(newIndex: number): void;
+
+  /** Duplicates this property object. */
+  duplicate(): PropertyBase;
+
+  /** Gets a member property or group. Strictly, this should be PropertyGroup method. */
+  property(index: number): PropertyBase;
+  property(name: string): PropertyBase;
+}
+
+/** The PropertyGroup object represents a group of properties. It can contain Property objects and other PropertyGroup objects. Property groups can be nested to provide a parent-child hierarchy, with a Layer object at the top (root) down to a single Property object, such as the mask feather of the third mask. To traverse the group hierarchy, use PropertyBase methods and attributes. */
+declare class PropertyGroup extends PropertyBase {
+  /** The number of indexed properties in the group. */
+  readonly numProperties: number;
+
+  /** Gets a member property or group. */
+  //property(index: number): PropertyBase;
+  //property(name: string): PropertyBase;
+
+  /** Reports whether a property can be added to the group. */
+  canAddProperty(name: string): boolean;
+
+  /** Adds a property to the group. */
+  addProperty(name: string): PropertyBase;
+}
+
+/** The RenderQueue object represents the render automation process, the data and functionality that is available through the Render Queue panel of a particular After Effects project. Attributes provide access to items in the render queue and their render status. Methods can start, pause, and stop the rendering process. */
+declare class RenderQueue {
+  /** When true, a render is in progress. */
+  readonly rendering: boolean;
+
+  /** The total number of items in the render queue. */
+  readonly numItems: number;
+
+  /** CC 2017(14.0)- */
+  readonly canQueueInAME: boolean;
+
+  /** The collection of items in the render queue. */
+  readonly items: RQItemCollection;
+
+  /** Show or hides the Render Queue panel. */
+  showWindow(doShow: boolean): void;
+
+  /** Starts the rendering process; does not return until render is complete. */
+  render(): void;
+
+  /** Pauses or restarts the rendering process. */
+  pauseRendering(pause: boolean): void;
+
+  /** Stops the rendering process. */
+  stopRendering(): void;
+
+  /** Gets a render-queue item from the collection. */
+  item(index: number): RenderQueueItem;
+
+  /** CC 2017(14.0)- */
+  queueInAME(render_immediately_in_AME: boolean): void;
+}
+
+/** The RenderQueueItem object represents an individual item in the render queue. It provides access to the specific settings for an item to be rendered. Create the object by adding a composition to the Render Queue with the RQItemCollection object; */
+declare class RenderQueueItem {
+  /** The total number of Output Modules assigned to the item. */
+  readonly numOutputModules: number;
+
+  /** When true, this item is rendered when the queue is started. */
+  render: boolean;
+
+  /** The time when rendering began for the item. */
+  readonly startTime: Date | null;
+
+  /** The time elapsed in the current rendering of this item. */
+  readonly elapsedSeconds: number | null;
+
+  /** The start time in the composition to be rendered. */
+  timeSpanStart: number;
+
+  /** The duration of the composition to be rendered. */
+  timeSpanDuration: number;
+
+  /** The number of frames to skip when rendering this item. */
+  skipFrames: number;
+
+  /** The composition to be rendered by this item. */
+  readonly comp: CompItem;
+
+  /** The collection of Output Modules for this item. */
+  readonly outputModules: OMCollection;
+
+  /** A set of Render Settings templates. */
+  readonly templates: string[];
+
+  /** The current rendering status of the item. */
+  readonly status: RQItemStatus;
+
+  /** A callback function that is called during the rendering process when the status of the item changes. */
+  onStatusChanged: string | null;
+
+  /** A log type for this item. */
+  logType: LogType;
+
+  /** Gets an Output Module for the item. */
+  outputModule(index: number): OutputModule;
+
+  /** Removes the item from the render queue. */
+  remove(): void;
+
+  /** Saves a new Render Settings template. */
+  saveAsTemplate(name: string): void;
+
+  /** Applies a Render Settings template. */
+  applyTemplate(templateName: string): void;
+
+  /** Duplicates this item. */
+  duplicate(): RenderQueueItem;
+
+  getSetting(key: string): string | number;
+
+  getSettings(format: GetSettingsFormat): Object;
+
+  setSetting(key: string, value: string | number): void;
+
+  setSettings(settings: Object): void;
+}
+
+/** The RQItemCollection contains all of the render-queue items in a project, as shown in the Render Queue panel of the project. The collection provides access to the RenderQueueItem objects, and allows you to create them from compositions. The first RenderQueueItem object in the collection is at index position 1. */
+declare class RQItemCollection extends Collection {
+  /** Retrieves an RenderQueueItem in the collection by its index number. The first object is at index 1. */
+  [index: number]: RenderQueueItem;
+
+  /** Adds a composition to the Render Queue. */
+  add(comp: CompItem): RenderQueueItem;
+}
+
+/** The Settings object provides an easy way to manage settings for scripts. The settings are saved in the After Effects preferences file and are persistent between application sessions. Settings are identified by section and key within the file, and each key name is associated with a value. In the preferences file, section names are enclosed in brackets and quotation marks, and key names are listing in quotation marks below the section name. All values are strings. */
+declare class Settings {
+  /** Saves a default value for a setting. */
+  saveSetting(sectionName: string, keyName: string, value: string, type?: PREFType): void;
+
+  /** Retrieves a setting value. */
+  getSetting(sectionName: string, keyName: string, type?: PREFType): string;
+
+  /** Reports whether a specified setting is assigned. */
+  haveSetting(sectionName: string, keyName: string, type?: PREFType): boolean;
+}
+
+/** The Shape object encapsulates information describing a shape in a shape layer, or the outline shape of a Mask. */
+declare class Shape {
+  /** When true, the shape is a closed curve. */
+  closed: boolean;
+
+  /** The anchor points of the shape. */
+  vertices: [number, number][];
+
+  /** The tangent vectors coming into the shape vertices. */
+  inTangents: [number, number][];
+
+  /** The tangent vectors coming out of the shape vertices. */
+  outTangents: [number, number][];
+
+  /** The mask path segment (sections of a mask path between vertices) containing each feather point. */
+  featherSegLocs: number[];
+
+  /** The relative position of each feather point on its mask path segment. */
+  featherRelSegLocs: number[];
+
+  /** The feather amount (radius) for each feather point. */
+  featherRadii: number[];
+
+  /** The feather radius interpolation type for each feather point. */
+  featherInterps: number[];
+
+  /** The feather tension at each feather point. */
+  featherTensions: number[];
+
+  /** The direction (inner or outer) of each feather point. */
+  featherTypes: number[];
+
+  /** The relative angle between the two normals on either side of a curved outer feather boundary at a corner on a mask path. */
+  featherRelCornerAngles: number[];
+}
+
+/** The ShapeLayer object represents a shape layer within a composition. Create it using the LayerCollection object’s addShape() method. */
+declare class ShapeLayer extends AVLayer { }
+
+/** The SolidSource object represents a solid-color footage source. */
+declare class SolidSource extends FootageSource {
+  /** The color of the solid. */
+  color: [number, number, number];
+}
+
+/** The file specification, an ExtendScript File object. */
+declare class Swatch {
+  /** The ASE version number. */
+  majorVersion: number;
+
+  /** The ASE version number. */
+  minorVersion: number;
+
+  /** An array of SwatchValue. */
+  values: SwatchValue[];
+}
+
+/** The file specification, an ExtendScript File object. */
+declare class SwatchValue {
+  /** One of "RGB", "CMYK", "LAB", "Gray" */
+  type: "RGB" | "CMYK" | "LAB" | "Gray";
+
+  /** When type = "RGB", the color values in the range [0.0..1.0]. 0, 0, 0 is Black. */
+  r: number;
+  g: number;
+  b: number;
+
+  /** When type = "CMYK", the color values in the range [0.0..1.0]. 0, 0, 0, 0 is White. */
+  c: number;
+  m: number;
+  y: number;
+  k: number;
+
+  /** When type = "LAB", the color values. L is in the range [0.0..1.0]. a and b are in the range [-128.0..+128.0] 0, 0, 0 is Black. */
+  L: number;
+  a: number;
+  // b:number;
+
+  /** When type = "Gray", the value range is [0.0..1.0]. 0.0 is Black. */
+  gray: number;
+  value: number;
+}
+
+/** The System object provides access to attributes found on the user’s system, such as the user name and the name and version of the operating system. It is available through the system global variable. */
+declare class System {
+  /** The current user name. */
+  readonly userName: string;
+
+  /** The name of the host computer. */
+  readonly machineName: string;
+
+  /** The name of the operating system. */
+  readonly osName: string;
+
+  /** The version of the operating system. */
+  readonly osVersion: string;
+
+  /** Execute’s a command on the system’s command line. */
+  callSystem(cmdLineToExecute: string): string;
+}
+
+/** The TextDocument object stores a value for a TextLayer's Source Text property. Create it with the constructor, passing the string to be encapsulated. */
+declare class TextDocument {
+  constructor(docText: string);
+
+  /** The text layer’s Source Text value. */
+  text: string;
+
+  /** The text layer’s font specified by its PostScript name. */
+  font: string;
+
+  /** string with path of font file, providing its location on disk (not guaranteed to be returned for all font types; return value may be empty string for some kinds of fonts) */
+  readonly fontLocation: string;
+
+  /** string with style information — e.g., “bold”, “italic” */
+  readonly fontStyle: string;
+
+  /** a string with the name of the font family */
+  readonly fontFamily: string;
+
+  /** The text layer’s font size in pixels. */
+  fontSize: number;
+
+  /** When true, the text layer shows a fill. */
+  applyFill: boolean;
+
+  /** When true, the text layer shows a stroke. */
+  applyStroke: boolean;
+
+  /** The text layer’s fill color. */
+  fillColor: [number, number, number];
+
+  /** The text layer’s stroke color. */
+  strokeColor: [number, number, number];
+
+  /** Indicates the rendering order for the fill and stroke of a text layer. */
+  strokeOverFill: boolean;
+
+  /** The text layer’s stroke thickness. */
+  strokeWidth: number;
+
+  /** The paragraph justification for the text layer. */
+  justification: ParagraphJustification;
+
+  /** The text layer’s spacing between characters. */
+  tracking: number;
+
+  /** When true, the text layer is point (unbounded) text. */
+  readonly pointText: boolean;
+
+  /** When true, the text layer is paragraph (bounded) text. */
+  readonly boxText: boolean;
+
+  /** For box text, the pixel dimensions for the text bounds. */
+  boxTextSize: [number, number];
+
+  /** CC 2014.2(13.2)- */
+  readonly fauxBold: boolean;
+
+  /** CC 2014.2(13.2)- */
+  readonly fauxItalic: boolean;
+
+  /** CC 2014.2(13.2)- */
+  readonly allCaps: boolean;
+
+  /** CC 2014.2(13.2)- */
+  readonly smallCaps: boolean;
+
+  /** CC 2014.2(13.2)- */
+  readonly superscript: boolean;
+
+  /** CC 2014.2(13.2)- */
+  readonly subscript: boolean;
+
+  /** CC 2014.2(13.2)- */
+  readonly verticalScale: number;
+
+  /** CC 2014.2(13.2)- */
+  readonly horizontalScale: number;
+
+  /** CC 2014.2(13.2)- */
+  readonly baselineShift: number;
+
+  /** CC 2014.2(13.2)- */
+  readonly tsume: number;
+
+  /** CC 2014.2(13.2)- */
+  readonly boxTextPos: [number, number];
+
+  /** CC 2015(13.6)- */
+  readonly baselineLocs: number[];
+
+  /** Restores the default character settings in the Character panel. */
+  resetCharStyle(): void;
+
+  /** Restores the default paragraph settings in the Paragraph panel. */
+  resetParagraphStyle(): void;
+}
+
+/** The TextLayer object represents a text layer within a composition. Create it using the LayerCollection object’s addText method. */
+declare class TextLayer extends AVLayer {
+  readonly source: null;
+
+  readonly text: _TextProperties;
+}
+
+/** The Viewer object represents a Composition, Layer, or Footage panel. */
+declare class Viewer {
+  /** The type of content in the viewer. */
+  readonly type: ViewerType;
+
+  /** When true, the viewer is focused. */
+  readonly active: boolean;
+
+  activeViewIndex: number;
+
+  readonly views: View[];
+
+  /** When true, the viewer is at its maximized size. */
+  maximized: boolean;
+
+  /** Moves the viewer to front and places focus on it. */
+  setActive(): boolean;
+}
+
+declare class View {
+  readonly active: boolean;
+  readonly options: ViewOptions;
+
+  setActive(): void;
+}
+
+declare class ViewOptions {
+  channels: ChannelType;
+  checkerboards: boolean;
+  exposure: number;
+  fastPreview: FastPreviewType;
+  zoom: number;
+}
+
+/*
+* Properties for Shortcuts
+*/
+declare class _TransformGroup extends PropertyGroup {
+  readonly anchorPoint: Property;
+  readonly position: Property;
+  readonly xPosition: Property;
+  readonly yPosition: Property;
+  readonly zPosition: Property;
+  readonly scale: Property;
+  readonly orientation: Property;
+  readonly rotation: Property;
+  readonly xRotation: Property;
+  readonly yRotation: Property;
+  readonly zRotation: Property;
+  readonly opacity: Property;
+}
+
+declare class _LightOptionsGroup extends PropertyGroup {
+  readonly intensity: Property;
+  readonly color: Property;
+  readonly coneAngle: Property;
+  readonly coneFeather: Property;
+  readonly falloff: Property;
+  readonly radius: Property;
+  readonly falloffDistance: Property;
+  readonly castsShadows: Property;
+  readonly shadowDarkness: Property;
+  readonly shadowDiffusion: Property;
+}
+
+declare class _CameraOptionsGroup extends PropertyGroup {
+  readonly zoom: Property;
+  readonly depthOfField: Property;
+  readonly focusDistance: Property;
+  readonly aperture: Property;
+  readonly blurLevel: Property;
+  readonly irisShape: Property;
+  readonly irisRotation: Property;
+  readonly irisRoundness: Property;
+  readonly irisAspectRatio: Property;
+  readonly irisDiffractionFringe: Property;
+  readonly highlightGain: Property;
+  readonly highlightThreshold: Property;
+  readonly highlightSaturation: Property;
+}
+
+declare class _LayerStyles extends PropertyGroup {
+  readonly blendingOption: _BlendOptionsGroup;
+  readonly dropShadow: _DropShadow;
+  readonly innerShadow: _InnerShadow;
+  readonly outerGlow: _OuterGlow;
+  readonly innerGlow: _InnerGlow;
+  readonly bevelAndEmboss: _BevelAndEmboss;
+  readonly satin: _Satin;
+  readonly colorOverlay: _ColorOverlay;
+  readonly gradientOverlay: _GradientOverlay;
+  readonly stroke: _Stroke;
+}
+
+declare class _BlendOptionsGroup extends PropertyGroup {
+  readonly globalLightAngle: Property;
+  readonly globalLightAltitude: Property;
+  readonly advancedBlending: _AdvBlendGroup;
+}
+
+declare class _AdvBlendGroup extends PropertyGroup {
+  readonly fillOpacity: Property;
+  readonly red: Property;
+  readonly green: Property;
+  readonly blue: Property;
+  readonly blendInteriorStylesAsGroup: Property;
+  readonly useBlendRangesFromSource: Property;
+}
+
+declare class _DropShadow extends PropertyGroup {
+  readonly blendMode: Property;
+  readonly color: Property;
+  readonly opacity: Property;
+  readonly useGlobalLight: Property;
+  readonly angle: Property;
+  readonly distance: Property;
+  readonly spread: Property;
+  readonly size: Property;
+  readonly noise: Property;
+  readonly layerKnocksOutDropShadow: Property;
+}
+
+declare class _InnerShadow extends PropertyGroup {
+  readonly blendMode: Property;
+  readonly color: Property;
+  readonly opacity: Property;
+  readonly useGlobalLight: Property;
+  readonly angle: Property;
+  readonly distance: Property;
+  readonly choke: Property;
+  readonly size: Property;
+  readonly noise: Property;
+}
+
+declare class _OuterGlow extends PropertyGroup {
+  readonly blendMode: Property;
+  readonly opacity: Property;
+  readonly noise: Property;
+  readonly colorType: Property;
+  readonly color: Property;
+  readonly colors: Property;
+  readonly gradientSmoothness: Property;
+  readonly technique: Property;
+  readonly spread: Property;
+  readonly size: Property;
+  readonly range: Property;
+  readonly jitter: Property;
+}
+
+declare class _InnerGlow extends PropertyGroup {
+  readonly blendMode: Property;
+  readonly opacity: Property;
+  readonly noise: Property;
+  readonly colorType: Property;
+  readonly color: Property;
+  readonly colors: Property;
+  readonly gradientSmoothness: Property;
+  readonly technique: Property;
+  readonly source: Property;
+  readonly choke: Property;
+  readonly size: Property;
+  readonly range: Property;
+  readonly jitter: Property;
+}
+
+declare class _BevelAndEmboss extends PropertyGroup {
+  readonly style: Property;
+  readonly technique: Property;
+  readonly depth: Property;
+  readonly direction: Property;
+  readonly size: Property;
+  readonly soften: Property;
+  readonly useGlobalLight: Property;
+  readonly angle: Property;
+  readonly altitude: Property;
+  readonly highlightMode: Property;
+  readonly highlightColor: Property;
+  readonly highlightOpacity: Property;
+  readonly shadowMode: Property;
+  readonly shadowColor: Property;
+  readonly shadowOpacity: Property;
+}
+
+declare class _Satin extends PropertyGroup {
+  readonly blendMode: Property;
+  readonly color: Property;
+  readonly opacity: Property;
+  readonly angle: Property;
+  readonly distance: Property;
+  readonly size: Property;
+  readonly invert: Property;
+}
+
+declare class _ColorOverlay extends PropertyGroup {
+  readonly blendMode: Property;
+  readonly color: Property;
+  readonly opacity: Property;
+}
+
+declare class _GradientOverlay extends PropertyGroup {
+  readonly blendMode: Property;
+  readonly opacity: Property;
+  readonly colors: Property;
+  readonly gradientSmoothness: Property;
+  readonly angle: Property;
+  readonly style: Property;
+  readonly reverse: Property;
+  readonly alignWithLayer: Property;
+  readonly scale: Property;
+  readonly offset: Property;
+}
+
+declare class _Stroke extends PropertyGroup {
+  readonly color: Property;
+  readonly blendMode: Property;
+  readonly size: Property;
+  readonly opacity: Property;
+  readonly position: Property;
+}
+
+declare class _GeometryOptionsGroup extends PropertyGroup {
+  readonly curvature: Property;
+  readonly segments: Property;
+
+  readonly bevelStyle: Property;
+  readonly bevelDepth: Property;
+  readonly holeBevelDepth: Property;
+  readonly extrusionDepth: Property;
+}
+
+declare class _MaterialOptionsGroup extends PropertyGroup {
+  readonly castsShadows: Property;
+  readonly lightTransmission: Property;
+  readonly acceptsShadows: Property;
+  readonly acceptsLights: Property;
+  readonly appearsInReflections: Property;
+  readonly ambient: Property;
+  readonly diffuse: Property;
+  readonly specularIntensity: Property;
+  readonly specularShininess: Property;
+  readonly metal: Property;
+  readonly reflectionIntensity: Property;
+  readonly reflectionSharpness: Property;
+  readonly reflectionRolloff: Property;
+  readonly transparency: Property;
+  readonly transparencyRolloff: Property;
+  readonly indexOfRefraction: Property;
+}
+
+declare class _AudioGroup extends PropertyGroup {
+  readonly audioLevels: Property;
+}
+
+declare class _TextProperties extends PropertyGroup {
+  readonly sourceText: Property;
+  readonly pathOption: _TextPathOptions;
+  readonly moreOption: _TextMoreOptions;
+}
+
+declare class _TextPathOptions extends PropertyGroup {
+  readonly path: Property;
+}
+
+declare class _TextMoreOptions extends PropertyGroup {
+  readonly anchorPointGrouping: Property;
+  readonly groupingAlignment: Property;
+  readonly fillANdStroke: Property;
+  readonly interCharacterBlending: Property;
+}

--- a/AfterEffects/2018/tsconfig.json
+++ b/AfterEffects/2018/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "strict": true,
+    "noLib": true
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/ScriptUI/index.d.ts
+++ b/ScriptUI/index.d.ts
@@ -1,473 +1,555 @@
 /// <reference path="../JavaScript/index.d.ts" />
 
-/**
- * A global class containing central information about ScriptUI. Not instantiable.
- */
-declare class ScriptUI {
-	/**
-	 * Collects the enumerated values that can be used in the alignment and alignChildren properties of controls and containers.
-	 * Predefined alignment values are: TOP, BOTTOM, LEFT, RIGHT, FILL, CENTER
-	 */
-	static readonly Alignment: string;
+declare type Margins = [number, number, number, number];
 
-	/**
-	 * Collects the enumerated values that can be used as the style argument to the ScriptUI.newFont() method.
-	 * Predefined styles are REGULAR, BOLD, ITALIC, BOLDITALIC.
-	 */
-	static readonly FontStyle: Object;
+declare type Alignment = number | 'top' | 'bottom' | 'left' | 'right' | 'fill' | 'center';
 
-	/**
-	 * The font constants defined by the host application.
-	 */
-	static readonly applicationFonts: Object;
-
-	/**
-	 * An object whose properties are the names of compatability modes supported by the host application.
-	 * The presence of ScriptUI.compatability.su1PanelCoordinates means that the application allows backward compatibility with the coordinate system of Panel elements in ScriptUI version 1.
-	 */
-	static readonly compatibility: Object;
-
-	/**
-	 * A string containing the internal version number of the ScriptUI module.
-	 */
-	static readonly coreVersion: string;
-
-	/**
-	 * An object whose properties define attributes of the environment in which ScriptUI operates.
-	 */
-	static readonly environment: Environment;
-
-	/**
-	 * An object whose properties and methods provide access to objects used in the ScriptUI event system.
-	 * It contains one function, createEvent(), which allows you to create event objects in order to simulate user-interaction event
-	 */
-	static readonly events: Events;
-
-	/**
-	 * A string containing the name of the UI component framework with which this version of ScriptUI is compatible.
-	 */
-	static readonly frameworkName: string;
-
-	/**
-	 * A string containing the version number of the ScriptUI component framework
-	 */
-	static readonly version: any;
-
-	/**
-	 * Finds and returns the resource for a given text string from the host application's resource data.
-	 * If no string resource matches the given text, the text itself is returned.
-	 * @param text The text to match.
-	 */
-	static getResourceText(text: string): string;
-
-	/**
-	 * Creates a new font object for use in text controls and titles.
-	 * @param name The font name, or the font family name.
-	 * @param style The font style; can be string, or one of the values of ScriptUI.FontStyle.
-	 * @param size The font size in points.
-	 */
-	static newFont(name: string, style: string, size: number): ScriptUIFont;
-
-	/**
-	 * Loads a new image from resources or disk files into an image object.
-	 * Creates a new global image object for use in controls that can display images, loading the associated images from the specified resources or image files.
-	 * @param normal The resource name or the disk file path to the image used for the normal state.
-	 * @param disabled The resource name, or the disk file path to the image used for the disabled state.
-	 * @param pressed The resource name, or the file-system path to the image used for the pressed state.
-	 * @param rollover The resource name, or the file-system path to the image used for the rollover state.
-	 */
-	static newImage(normal: string, disabled?: string, pressed?: string, rollover?: string): ScriptUIImage;
-
+declare module ScriptUI {
+	export enum Alignment {
+		TOP,
+		BOTTOM,
+		LEFT,
+		RIGHT,
+		FILL,
+		CENTER
+	}
+	
+	export enum FontStyle {
+		REGULAR,
+		BOLD,
+		ITALIC,
+		BOLDITALIC
+	}
 }
 
-/**
- * The instance represents a top-level window or dialog box, which contains user-interface elements.
- * The globally available Window object provides access to predefined and script-defined windows.
- */
-declare class Window {
-	/**
-	 * Set to true to make this window active.
-	 * A modal dialog that is visible is by definition the active dialog.
-	 * An active palette is the front-most window.
-	 * An active control is the one with focus—that is, the one that accepts keystrokes, or in the case of a Button, be selected when the user typesReturn or Enter.
-	 */
-	active: boolean;
+declare class ScriptUI {
+	static compatibility: any;
+	static coreVersion: string;
+	static environment: {
+		keyboardState: {
+			keyName: string;
+			shiftKey: boolean;
+			ctrlKey: boolean;
+			altKey: boolean;
+			metaKey: boolean;
+		}
+	};
+	static events: {
+		createEvent(eventType: string): UIEvent
+	};
+	static frameworkName: string;
+	static version: string;
+	static getResourceText(text: string): string;
+	static newFont(name: string, style: ScriptUI.FontStyle, size: number): ScriptUIFont;
+	static newImage(normal: string, disabled: string, pressed: string, rollover: string): ScriptUIImage;
+}
 
-	/**
-	 * Tells the layout manager how unlike-sized children of this container should be aligned within a column or row.
-	 * Order of creation determines which children are at the top of a column or the left of a row; the earlier a child is created, the closer it is to the top or left of its column or row. If defined, alignment for a child element overrides the alignChildren setting for the parent container. See alignment property for values.
-	 */
-	alignChildren: string;
+declare class ScriptUIGraphics {
+	BrushType: {SOLID_COLOR: number; THEME_COLOR: number;};
+	PenType: {SOLID_COLOR: number; THEME_COLOR: number;};
+	backgroundColor: ScriptUIBrush;
+	currentPath: ScriptUIPath;
+	currentPoint: Point;
+	disabledBackgroundColor: ScriptUIBrush;
+	disabledForegroundColor: ScriptUIPen;
+	font: ScriptUIFont;
+	foregroundColor: ScriptUIPen;
+	
+	closePath(): void;
+	drawFocusRing(left: number, top: number, width?: number, height?: number): void;
+	drawImage(image: ScriptUIImage, left: number, top: number, width?: number, height?: number): void;
+	drawOSControl(): void;
+	drawString(text: string, pen: ScriptUIPen, x: number, y: number, font: ScriptUIFont): void;
+	ellipsePath(left: number, top: number, width?: number, height?: number): Point;
+	fillPath(brush: ScriptUIBrush, path?: ScriptUIPath): void;
+	lineto(x: number, y: number): Point;
+	measureString(text: string, font: ScriptUIFont, boundingWidth?: number): Dimension;
+	moveto(x: number, y: number): Point;
+	newBrush(brushType: number, color: [number, number, number, number] | string): ScriptUIBrush;
+	newPath(): ScriptUIPath;
+	newPen(penType: number, color: [number, number, number, number] | string, lineWidth: number): ScriptUIPen;
+	rectPath(left: number, top: number, width?: number, height?: number): Point;
+	strokePath(pen: ScriptUIPen): void;
+}
 
-	/**
-	 * The alignment style for child elements of a container. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
+declare class ScriptUIBrush {
+	color: [number, number, number, number];
+	theme: string;
+	type: number;
+}
 
-	/**
-	 * The bounds of the window's drawable area, excluding the frame, in screen coordinates.
-	 */
-	bounds: Bounds;
+declare class ScriptUIFont {
+	family: string;
+	name: string;
+	size: number;
+	style: ScriptUI.FontStyle;
+	substitute: string;
+}
 
-	/**
-	 * For windows of type dialog, the UI element to notify when the user presses a cancellation key combination.
-	 * The cancellation key is the Esc key. By default, looks for a button whose name or text is "cancel" (case disregarded).
-	 */
-	cancelElement: Object;
-
-	/**
-	 * A number of characters for which to reserve space when calculating the preferred size of the window.
-	 */
-	characters: number;
-
-	/**
-	 * The collection of UI elements that have been added to this container.
-	 * An array indexed by number or by a string containing an element's name. The length property of this array is the number of child elements for container elements, and is zero for controls.
-	 */
-	readonly children: Object[];
-
-	/**
-	 * For windows of type dialog, the UI element to notify when the user presses a Enter key.
-	 * By default, looks for a button whose name or text is "ok" (case disregarded).
-	 */
-	defaultElement: Object;
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The bounds of the window frame in screen coordinates.
-	 * The frame consists of the title bar and borders that enclose the content region of a window, depending on the windowing system.
-	 */
-	readonly frameBounds: Bounds;
-
-	/**
-	 * The top left corner of the window frame in screen coordinates.
-	 * The same as [frameBounds.x, frameBounds.y]. Set this value to move the window frame to the specified location on the screen. The frameBounds value changes accordingly.
-	 */
-	frameLocation: Point;
-
-	/**
-	 * The size and location of the window's frame in screen coordinates.
-	 */
-	readonly frameSize: Dimension;
-
-	/**
-	 * Deprecated. Use ScriptUI.frameworkName instead.
-	 */
-	static readonly frameworkName: string;
-
-	/**
-	 * The graphics object that can be used to customize the window’s appearance, in response to the onDraw event.
-	 */
-	readonly graphics: ScriptUIGraphics;
-
-	/**
-	 * The help text that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The number of pixels to indent the element.
-	 */
-	indent: number;
-
-	/**
-	 * The default text justification style for child text elements.
-	 * One of left, center, or right. Justification only works if this value is set on creation of the element.
-	 */
-	justify: string;
-
-	/**
-	 * The layout manager for this container.
-	 * The first time a container object is made visible, ScriptUI invokes this layout manager by calling its layout() function. Default is an instance of the LayoutManager class that is automatically created when the container element is created.
-	 */
-	layout: LayoutManager;
-
-	/**
-	 * The upper left corner of the window's drawable area.
-	 * The same as [bounds.x, bounds.y].
-	 */
-	location: Point;
-
-	/**
-	 * The number of pixels between the edges of a container and the outermost child elements.
-	 * You can specify different margins for each edge of the container. The default value is based on the type of container, and is chosen to match the standard Adobe UI guidelines.
-	 */
-	margins: number;
-
-	/**
-	 * True if the window is expanded.
-	 */
-	maximized: boolean;
-
-	/**
-	 * The largest rectangle to which the window can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * True if the window is minimized or iconified.
-	 */
-	minimized: boolean;
-
-	/**
-	 * The smallest rectangle to which the window can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The opacity of the window, in the range [0..1].
-	 * A value of 1.0 (the default) makes the window completely opaque, a value of 0 makes it completely transparent. Intermediate values make it partially transparent to any degree.
-	 */
-	opacity: number;
-
-	/**
-	 * The layout orientation of children in a container.
-	 * Interpreted by the layout manager for the container. The default LayoutManager  Object accepts the (case-insensitive) values row, column, or stack.For window and panel, the default is column, and for group the default is row. The allowed values for the container’s alignChildren and its children’s alignment properties depend on the orientation.
-	 */
-	orientation: string;
-
-	/**
-	 * The immediate parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size of the window.
-	 * Used in automatic layout and resizing. To set a specific value for only one dimension, specify the other dimension as -1.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
-	 * Creation properties of a Window object can include:
-	 * resizeable: When true, the window can be resized by the user. Default is false.
-	 * su1PanelCoordinates: Photoshop only. When true, the child panels of this window automatically adjust the positions of their children for compatability with Photoshop CS (in which the vertical coordinate was measured from outside the frame). Default is false. Individual panels can override the parent window’s setting.
-	 * closeButton: Bridge only. When true, the title bar includes a button to close the window, if the platform and window type allow it. When false, it does not. Default is true. Not used for dialogs.
-	 * maximizeButton: Bridge only. When true, the title bar includes a button to expand the window to its maximum size (typically, the entire screen), if the platform and window type allow it. When false, it does not. Default is false for type palette, true for type window. Not used for dialogs.
-	 */
-	properties: Object;
-
-	/**
-	 * The keypress combination that invokes this element's onShortcutKey() callback.
-	 */
-	shortcutKey: string;
-
-	/**
-	 * The current size and location of the content area of the window in screen coordinates.
-	 */
+declare class ScriptUIImage {
+	format: string;
+	name: string;
+	pathname: string;
 	size: Dimension;
+}
 
-	/**
-	 * The number of pixels separating one child element from its adjacent sibling element.
-	 * Because each container holds only a single row or column of children, only a single spacing value is needed for a container. The default value is based on the type of container, and is chosen to match standard Adobe UI guidelines.
-	 */
+declare class ScriptUIPath {}
+
+declare class ScriptUIPen {
+	color: [number, number, number, number];
+	lineWidth: number;
+	theme: string;
+	type: number;
+}
+
+declare class DrawState {
+	altKeyPressed: boolean;
+	capsLockKeyPressed: boolean;
+	cmdKeyPressed: boolean;
+	ctrlKeyPressed: boolean;
+	hasFocus: boolean;
+	leftButtonPressed: boolean;
+	middleButtonPressed: boolean;
+	mouseOver: boolean;
+	numLockKeyPressed: boolean;
+	optKeyPressed: boolean;
+	rightButtonPressed: boolean;
+	shiftKeyPressed: boolean;
+}
+
+declare class UIEvent {
+	bubbles: boolean;
+	cancelable: boolean;
+	currentTarget: any;
+	eventPhase: number;
+	target: any;
+	timeStamp: Date;
+	type: string;
+	view: any;
+	
+	initUIEvent(eventName: string, bubble: boolean, isCancelable: boolean, view: any, detail: number): void;
+	preventDefault(): void;
+	stopPropagation(): void;
+}
+
+declare class KeyboardEvent extends UIEvent {
+	altKey: boolean;
+	ctrlKey: boolean;
+	metaKey: boolean;
+	shiftKey: boolean;
+	keyIdentifier: string;
+	keyLocation: number;
+	keyName: string;
+	type: string;
+	
+	getModifierState(keyIdentifier: string): boolean;
+	initKeyboardEvent(eventName: string, bubble: boolean, isCancelable: boolean, view: any, keyID: string, keyLocation: number, modifiersList: string): void;
+}
+
+declare class MouseEvent extends UIEvent {
+	altKey: boolean;
+	button: number;
+	clientX: number;
+	clientY: number;
+	ctrlKey: boolean;
+	detail: number;
+	metaKey: boolean;
+	relatedTarget: any;
+	screenX: number;
+	screenY: number;
+	shiftKey: boolean;
+	type: string;
+	
+	getModifierState(keyIdentifier: string): boolean;
+	initMouseEvent (eventName: string, bubble: boolean, isCancelable: boolean, view: any, detail: number, screenX: number, screenY: number, clientX: number, clientY: number, ctrlKey: boolean, altKey: boolean, shiftKey: boolean, metaKey: boolean, button: number, relatedTarget?: any): void;
+}
+
+declare interface _LayoutManager {
+	layout(recalculate?: boolean): void;
+	resize(): void;
+}
+
+declare class AutoLayoutManager implements _LayoutManager {
+  layout(recalculate?: boolean): void;
+	resize(): void;
+}
+
+interface _TitleLayout {
+	alignment: [Alignment, Alignment];
+	characters: number;
 	spacing: number;
+	margins: Margins;
+	justify: string;
+	truncate: string;
+}
 
-	/**
-	 * The title, label, or displayed text, a localizeable string.
-	 * Does not apply to containers of type group.
-	 */
+declare class _WindowOrContainer {
+	alignChildren: Alignment | [Alignment, Alignment];
+	alignment: Alignment | [Alignment, Alignment];
+	bounds: Bounds;
+	children: (_Container|_Control)[];
+	enabled: boolean;
+	graphics: ScriptUIGraphics;
+	helpTip: string;
+	layout: _LayoutManager;
+	location: Point;
+	margins: Margins|number;
+	maximumSize: Dimension;
+	minimumSize: Dimension;
+	orientation: 'row' | 'column' | 'stack';
+	parent: _WindowOrContainer;
+	preferredSize: Dimension;
+	properties: any;
+	size: Dimension;
+	spacing: number;
+	type: string;
+	visible: boolean;
+	window: Window;
+	windowBounds: Bounds;
+	
+	add(type: 'button', bounds?: Bounds, text?: string, creation_properties?: {name?: string;}): Button;
+	add(type: 'checkbox', bounds?: Bounds, text?: string, creation_properties?: {name?: string;}): Checkbox;
+	add(type: 'dropdownlist', bounds?: Bounds, items?: string[], creation_properties?: {name?: string; items?: string[];}): DropDownList;
+	add(type: 'edittext', bounds?: Bounds, text?: string, creation_properties?: {name?: string; readonly?: boolean; noecho?: boolean; enterKeySignalsOnChange?: boolean; borderless?: boolean; multiline?: boolean; scrollable?: boolean;}): EditText;
+	add(type: 'flashplayer', bounds?: Bounds, movieToLoad?: string | File, creation_properties?: {name?: string;}): FlashPlayer;
+	add(type: 'group', bounds?: Bounds, creation_properties?: {name?: string;}): Group;
+	add(type: 'iconbutton', bounds?: Bounds, icon?: string | File, creation_properties?: {name?: string; style?: string; toggle?: boolean;}): IconButton;
+	add(type: 'image', bounds?: Bounds, icon?: string | File, creation_properties?: {name?: string;}): Image;
+	add(type: 'listbox', bounds?: Bounds, items?: string[], creation_properties?: {name?: string; multiselect?: boolean; items?: string[]; numberOfColumns?: number; showHeaders?: boolean; columnWidths?: number[]; columnTitles?: string[];}): ListBox;
+	add(type: 'panel', bounds?: Bounds, text?: string, creation_properties?: {name?: string; borderStyle?: string; su1PanelCoordinates?: boolean;}): Panel;
+	add(type: 'progressbar', bounds?: Bounds, value?: number, minvalue?: number, maxvalue?: number, creation_properties?: {name?: string;}): ProgressBar;
+	add(type: 'radiobutton', bounds?: Bounds, text?: string, creation_properties?: {name?: string;}): RadioButton;
+	add(type: 'scrollbar', bounds?: Bounds, value?: number, minvalue?: number, maxvalue?: number, creation_properties?: {name?: string;}): Scrollbar;
+	add(type: 'slider', bounds?: Bounds, value?: number, minvalue?: number, maxvalue?: number, creation_properties?: {name?: string;}): Slider;
+	add(type: 'statictext', bounds?: Bounds, text?: string, creation_properties?: {name?: string; multiline?: boolean; scrolling?: boolean; truncate?: string;}): StaticText;
+	add(type: 'tab', bounds?: Bounds, text?: string, creation_properties?: {name?: string;}): Tab;
+	add(type: 'tabbedpanel', bounds?: Bounds, text?: string, creation_properties?: {name?: string;}): TabbedPanel;
+	add(type: 'treeview', bounds?: Bounds, items?: string[], creation_properties?: {name?: string; itmes?: string[];}): TreeView;
+	addEventListener(eventName: string, handler: (e: UIEvent) => void, capturePhase?: boolean): void;
+	dispatchEvent(eventObj: UIEvent): boolean;
+	findElement(name: string): any;
+	hide(): void;
+	notify(event: string): void;
+	remove(index: number): void;
+	remove(text: string): void;
+	remove(child: any): void;
+	removeEventListener(eventName: string, handler: (e: UIEvent) => void, capturePhase?: boolean): void;
+	show(): any;
+	
+	onDraw: Function;
+	onActivate: Function;
+	onClose: Function;
+	onDeactivate: Function;
+	onMove: Function;
+	onMoving: Function;
+	onResize: Function;
+	onResizing: Function;
+	onShortcutKey: Function;
+	onShow: Function;
+}
+
+declare class Window extends _WindowOrContainer{
+	static frameworkName: string;
+	static version: string;
+	
+	static alert(message: string, title?: string, errorIcon?: boolean): void;
+	static confirm(message: string, noAsDflt?: boolean, title?: string): boolean;
+	static find(resourceName: string): Window;
+	static find(type: string, title: string): Window;
+	static prompt(message: string, preset: string, title?: string): string;
+
+	constructor(type: 'dialog' | 'palette' | 'window', title?: string, bounds?: Bounds, creation_properties?: {
+		resizeable?: boolean;
+		closeButton?: boolean;
+		maximizeButton?: boolean;
+		minimizeButton?: boolean;
+		independent?: boolean;
+		borderless?: boolean;
+	});
+
+	active: boolean;
+	cancelElement: any;
+	defaultElement: any;
+	frameBounds: Bounds;
+	frameLocation: Point;
+	frameSize: Dimension;
+	maximized: boolean;
+	minimized: boolean;
+	opacity: number;
+	resizeable: boolean;
+	shortcutKey: string;
 	text: string;
 
-	/**
-	 * The element type; "dialog", "palette", or "window".
-	 */
-	readonly type: string;
-
-	/**
-	 * Deprecated. Use ScriptUI.version instead.
-	 */
-	static readonly version: any;
-
-	/**
-	 * When true, the element is shown, when false it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this window relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Creates a new window.
-	 * @param type The window type. One of: window: Creates a simple window that can be used as a main window for an application. (Not supported by Photoshop CS3.) palette: Creates a modeless dialog, also called a floating palette. (Not supported by Photoshop CS3.) dialog: Creates a modal dialog. This argument can also be a ScriptUI resource specification; in that case, all other arguments are ignored.
-	 * @param title The window title, a localizable string.
-	 * @param bounds The window's position and size.
-	 * @param properties An object containing creation-only properties. Can contain any of these properties: resizeable: When true, the window can be resized by the user. Default is false. su1PanelCoordinates: Photoshop only. When true, the child panels of this window automatically adjust the positions of their children for compatability with Photoshop CS (in which the vertical coordinate was measured from outside the frame). Default is false. Individual panels can override the parent window’s setting. closeButton:When true, the title bar includes a button to close the window, if the platform and window type allow it. When false, it does not. Default is true. Not used for dialogs. maximizeButton:When true, the title bar includes a button to expand the window to its maximum size (typically, the entire screen), if the platform and window type allow it. When false, it does not. Default is false for type palette, true for type window. Not used for dialogs. minimizeButton: When true, the title bar includes a button to minimize or iconify the window, if the platform and window type allow it. When false, it does not. Default is false for type palette, true for type window. Main windows cannot have a minimize button in Mac OS. Not used for dialogs. independent:When true, a window of type window is independent of other application windows, and can be hidden behind them in Windows. In Mac OS, has no effect. Default is false. borderless:When true, the window has no title bar or borders. Properties that control those features are ignored.
-	 */
-	constructor(type: string, title?: string, bounds?: Bounds, properties?: Object);
-
-	/**
-	 * Creates and returns a new control or container object and adds it to the children of this window.
-	 * @param type The type of the child element, as specified for the type property. Control types are listed in the JavaScript Tools Guide.
-	 * @param bounds A bounds specification that describes the size and position of the new control or container, relative to its parent. If supplied, this value creates a new Bounds object which is assigned to the new object’s bounds property.
-	 * @param text The text or label, a localizable string. Initial text to be displayed in the control as the title, label, or contents, depending on the control type. If supplied, this value is assigned to the new object’s text property.
-	 * @param properties An object that contains one or more creation properties of the new child (properties used only when the element is created). The creation properties depend on the element type. See properties property of each control type.
-	 */
-	add(type: string, bounds?: Bounds, text?: string, properties?: Object): Object;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this window.
-	 * @param eventName The name of the event. Predefined event names are: change, changing, move, moving, resize, resizing, show , enterKey, focus, blur, keydown, keyup, mousedown, mouseup, mousemove, mouseover, mouseout, click (detail = 1 for single, 2 for double).
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase?: boolean): boolean;
-
-	/**
-	 * Displays a platform-standard dialog containing a short message and an OK button.
-	 * @param message TThe string for the displayed message.
-	 * @param title A string to appear as the title of the dialog, if the platform supports a title. Ignored in Mac OS, which does not support titles for alert dialogs. The default title string is "Script Alert".
-	 * @param errorIcon When true, the platform-standard alert icon is replaced by the platform-standard error icon in the dialog. Ignored in Mac OS, which does not support icons for alert dialogs.
-	 */
-	static alert(message: string, title?: string, errorIcon?: boolean): void;
-
-	/**
-	 * Centers this window on screen or with repect to another window.
-	 * @param window The relative window. If not specified, centers on the screen.
-	 */
 	center(window?: Window): void;
+	close(result?: number): void;
+	update(): void;
+}
 
-	/**
-	 * Closes this window.
-	 * . If an onClose() callback is defined for the window, calls that function before closing the window.
-	 * @param return A number to be returned from the show() method that invoked this window as a modal dialog.
-	 */
-	close(return_?: any): void;
+declare class _Container extends _WindowOrContainer {
+	characters: number;
+}
 
-	/**
-	 * Displays a platform-standard dialog containing a short message and two buttons labeled Yes and No.
-	 * Returns true if the user clicked Yes, false if the user clicked No.
-	 * @param message The string for the displayed message.
-	 * @param noAsDefault When true, the No button is the default choice, selected when the user types Enter. Default is false, meaning that Yes is the default choice.
-	 * @param title A string to appear as the title of the dialog, if the platform supports a title. Ignored in Mac OS, which does not support titles for alert dialogs. The default title string is "Script Alert".
-	 */
-	static confirm(message: string, noAsDefault: boolean, title?: string): boolean;
+declare class Panel extends _Container {
+	text: string;
+}
 
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): UIEvent;
+declare class TabbedPanel extends _Container {
+	selection: Tab;
+	text: string;
+	title: string;
+	titleLayout: _TitleLayout;
+}
 
-	/**
-	 * Use this method to find an existing window.
-	 * This includes windows defined by ScriptUI resource strings, windows already created by a script, and windows created by the application (if the application supports this case). This function is not supported by all applications. Returns a Window object found or generated from the resource, or null if no such window or resource exists.
-	 * @param type The name of a predefined resource available to JavaScript in the current application; or the window type. If a title is specified, the type is used if more than one window with that title is found. Can be null or the empty string.
-	 * @param title The window title.
-	 */
-	static find(type: string, title: string): Window;
+declare class Tab extends _Container {
+	text: string;
+}
 
-	/**
-	 * Hides this windows.
-	 * When a window is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states. For a modal dialog, closes the dialog and sets its result to 0.
-	 */
+declare class Group extends _Container {}
+
+
+declare class __Control {
+	addEventListener(eventName: string, handler: (e: UIEvent) => void, capturePhase?: boolean): void;
+	dispatchEvent(eventObj: UIEvent): boolean;
 	hide(): void;
+	notify(event: string): void;
+	removeEventListener(eventName: string, handler: (e: UIEvent) => void, capturePhase?: boolean): void;
+	show(): any;
+	
+	onDraw: Function;
+	onEnterKey: Function;
+	onActivate: Function;
+	onDeactivate: Function;
+}
 
-	/**
-	 * Sends a notification message to all listeners, simulating the specified user interaction event.
-	 * @param eventName The event name; if omitted, the default event is sent. One of: onClose, onMove, onMoving, onResize, onResizing, onShow
-	 */
-	notify(eventName?: string): void;
+declare class _Control extends __Control {
+	alignment: Alignment | [Alignment, Alignment];
+	bounds: Bounds;
+	children: any[];
+	enabled: boolean;
+	graphics: ScriptUIGraphics;
+	helpTip: string;
+	indent: number;
+	location: Point;
+	maximumSize: Dimension;
+	minimumSize: Dimension;
+	parent: _WindowOrContainer;
+	preferredSize: Dimension;
+	properties: any;
+	size: Dimension;
+	type: string;
+	visible: boolean;
+	window: Window;
+	windowBounds: Bounds;
+}
 
-	/**
-	 * An event-handler callback function, called when the window acquires the keyboard focus.
-	 * Called when the user gives the window the keyboard focus by clicking it or otherwise making it the active window.
-	 */
-	onActivate(): void;
+declare class _ListControl extends _Control {
+	items: ListItem[];
+	itemSize: Dimension;
+	
+	add(type: 'item', text: string, index?: number): ListItem;
+	add(type: 'separator', text: string, index?: number): void;
+	add(type: 'node', text: string, index?: number): _Node;
+	find(text: string): ListItem;
+	remove(index: number): void;
+	remove(text: string): void;
+	remove(child: ListItem): void;
+	removeAll(): void;
+	
+	onChange: Function;
+}
 
-	/**
-	 * An event-handler callback function, calledwhen the window is about to be closed.
-	 * Called when a request is made to close the window, either by an explicit call to the close() function or by a user action (clicking the OS-specific close icon in the title bar). The function is called before the window actually closes; it can return false to cancel the close operation.
-	 */
-	onClose(): boolean;
+declare class Button extends _Control {
+	active: boolean;
+	justify: string;
+	shortcutKey: string;
+	text: string;
+	
+	onClick: Function;
+	onShortcutKey: Function;
+}
 
-	/**
-	 * An event-handler callback function, called when the window loses the keyboard focus.
-	 * Called when the user moves the keyboard focus from the previously active window to another window.
-	 */
-	onDeactivate(): void;
+declare class Checkbox extends _Control {
+	active: boolean;
+	characters: number;
+	justify: string;
+	shortcutKey: string;
+	text: string;
+	value: boolean;
+	
+	onClick: Function;
+	onShortcutKey: Function;
+}
 
-	/**
-	 * An event-handler callback function, calledwhen the windowhas been moved
-	 */
-	onMove(): void;
+declare class DropDownList extends _ListControl {
+	active: boolean;
+	selection: ListItem | number;
+	shortcutKey: string;
+	title: string;
+	titleLayout: _TitleLayout;
+	
+	onShortcutKey: Function;
+}
 
-	/**
-	 * An event-handler callback function, calledwhen the window is being moved
-	 * Called while a window in being moved, each time the position changes. A handler can monitor the move operation.
-	 */
-	onMoving(): void;
+declare class EditText extends _Control {
+	active: boolean;
+	characters: number;
+	justify: string;
+	shortcutKey: string;
+	text: string;
+	textselection: string;
+	
+	onChange: Function;
+	onChanging: Function;
+	onShortcutKey: Function;
+}
 
-	/**
-	 * An event-handler callback function, called after the window has been resized
-	 */
-	onResize(): void;
+declare class FlashPlayer extends _Control {
+	active: boolean;
+	shortcutKey: string;
+	title: string;
+	titleLayout: _TitleLayout;
+	
+	invokePlayerFunction(fnName: string, ...args: any[]): any;
+	loadMovie(file: File): void;
+	playMovie(rewind: boolean): void;
+	stopMovie(): void;
+	
+	onShortcutKey: Function;
+}
 
-	/**
-	 * An event-handler callback function, called while a window is being resized
-	 * Called while a window is being resized, each time the height or width changes. A handler can monitor the resize operation.
-	 */
-	onResizing(): void;
+declare class IconButton extends _Control {
+	active: boolean;
+	icon: string | File;
+	image: ScriptUI | string | File;
+	shortcutKey: string;
+	text: string;
+	title: string;
+	titleLayout: _TitleLayout;
+	
+	onClick: Function;
+	onShortcutKey: Function;
+}
 
-	/**
-	 * In Windows only, an event-handler callback function, called a shortcut-key sequence is typed that matches the shortcutKey value for this window.
-	 */
-	onShortcutKey(): void;
+declare class Image extends _Control {
+	active: boolean;
+	icon: string | File;
+	image: ScriptUI | string | File;
+	shortcutKey: string;
+	title: string;
+	titleLayout: _TitleLayout;
+	
+	onShortcutKey: Function;
+}
 
-	/**
-	 * An event-handler callback function, called just before the window is displayed
-	 * Called when a request is made to open the window using the show() method, before the window is made visible, but after automatic layout is complete. A handler can modify the results of the automatic layout.
-	 */
-	onShow(): void;
+declare class ListBox extends _ListControl {
+	active: boolean;
+	columns: {
+		titles: string[],
+		preferredWidths: number[]
+	};
+	selection: ListItem[] | ListItem | number;
+	shortcutKey: string;
+	
+	revealItem(item: ListItem): void;
 
-	/**
-	 * Displays a modal dialog that returns the user’s text input.
-	 * Returns the value of the text edit field if the user clicked OK, null if the user clicked Cancel.
-	 * @param prompt The string for the displayed message.
-	 * @param default The initial value to be displayed in the text edit field.
-	 * @param title A string to appear as the title of the dialog. In Windows, this appears in the window’s frame; in Mac OS it appears above the message. The default title string is "Script Prompt".
-	 */
-	static prompt(prompt: string, default_?: string, title?: string): string;
+	onDoubleClick: Function;
+	onShortcutKey: Function;
+}
 
-	/**
-	 * Removes the specified child control from this window’s children array.
-	 * No error results if the child does not exist.
-	 * @param what The child control to remove, specified by 0-based index, text property value, or as a control object.
-	 */
-	remove(what: any): void;
+declare class ListItem extends __Control{
+	checked: boolean;
+	enabled: boolean;
+	expanded: boolean;
+	icon: string | File;
+	image: ScriptUI | string | File;
+	index: number;
+	parent: any;
+	properties: any;
+	selected: boolean;
+	subitems: {
+		text: string;
+		image: Image;
+	}[];
+	text: string;
+	type: string;
+	
+	toString(): string;
+	valueOf(): number;
+}
 
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this window.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+declare class _Node extends ListItem {
+  add(type: 'item', name: string): ListItem;
+  add(type: 'node', name: string): _Node;
+  find(text: string): ListItem;
+	remove(index: number): void;
+	remove(text: string): void;
+	remove(child: ListItem): void;
+	removeAll(): void;
+}
 
-	/**
-	 * Makes this window visible.
-	 * If an onShow() callback is defined for a window, calls that function before showing the window.When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states. For a modal dialog, opens the dialog and does not return until the dialog is dismissed. If it is dismissed via the close() method, this method returns any result value passed to that method. Otherwise, returns 0.
-	 */
-	show(): number | any;
+declare class ProgressBar extends _Control {
+	maxvalue: number;
+	minvalue: number;
+	text: string;
+	value: number;
+}
 
+declare class RadioButton extends _Control {
+	active: boolean;
+	justify: string;
+	shortcutKey: string;
+	text: string;
+	value: boolean;
+	
+	onClick: Function;
+	onShortcutKey: Function;
+}
+
+declare class Scrollbar extends _Control {
+	active: boolean;
+	jumpdelta: number;
+	maxvalue: number;
+	minvalue: number;
+	shortcutKey: string;
+	stepdelta: number;
+	value: number;
+	
+	onChange: Function;
+	onChanging: Function;
+	onShortcutKey: Function;
+}
+
+declare class Slider extends _Control {
+	active: boolean;
+	maxvalue: number;
+	minvalue: number;
+	shortcutKey: string;
+	text: string;
+	value: number;
+	
+	onChange: Function;
+	onChanging: Function;
+	onShortcutKey: Function;
+}
+
+declare class StaticText extends _Control {
+	active: boolean;
+	characters: number;
+	justify: string;
+	shortcutKey: string;
+	text: string;
+	
+	onShortcutKey: Function;
+}
+
+declare class TreeView extends _ListControl {
+	active: boolean;
+	selection: ListItem
+	shortcutKey: string;
+	
+	onExpand: Function;
+	onCollapse: Function;
+	onShortcutKey: Function;
 }
 
 /**
@@ -487,2599 +569,6 @@ declare class LayoutManager {
 	 * Resizes the child elements of the managed container with a given alignment type, after the window has been resized by the user.
 	 */
 	resize(): void;
-
-}
-
-/**
- * A drawing pen that defines a color and line width used to stroke paths.
- * Create with ScriptUIGraphics.newPen(). Use as a value of  foregroundColor properties, and pass as an argument to drawString() and strokePath() methods.
- */
-declare class ScriptUIPen {
-	/**
-	 * The pen color.
-	 * The paint color to use when the type is SOLID_COLOR. An array in the form [R, B, G, A] specifying the red, green, blue values of the color and the opacity (alpha channel) value as numbers in the range [0.0..1.0]. An opacity of 0 is fully transparent, and an opacity of 1 is fully opaque.
-	 */
-	readonly color: number[];
-
-	/**
-	 * The pixel width of the drawing line.
-	 */
-	lineWidth: number;
-
-	/**
-	 * The theme name.
-	 * The name of a color theme to use for drawing when the type is THEME_COLOR. Theme colors are defined by the host application.
-	 */
-	readonly theme: string;
-
-	/**
-	 * The pen type, solid or theme.
-	 * One of these constants: ScriptUIGraphics.PenType.SOLID_COLOR or ScriptUIGraphics.PenType.THEME_COLOR
-	 */
-	readonly type: string;
-
-}
-
-/**
- * A painting brush that encapsulates a color or pattern used to fill paths.
- * Create with ScriptUIGraphics.newBrush(). Use as a value of  backgroundColor properties, and pass as an argument to the fillPath() method.
- */
-declare class ScriptUIBrush {
-	/**
-	 * The brush color.
-	 * The paint color to use when the type is SOLID_COLOR. An array in the form [R, B, G, A] specifying the red, green, blue values of the color and the opacity (alpha channel) value as numbers in the range [0.0..1.0]. An opacity of 0 is fully transparent, and an opacity of 1 is fully opaque.
-	 */
-	readonly color: number[];
-
-	/**
-	 * The theme name.
-	 * The name of a color theme to use for drawing when the type is THEME_COLOR. Theme colors are defined by the host application.
-	 */
-	readonly theme: string;
-
-	/**
-	 * The brush type, solid or theme.
-	 * One of these constants: ScriptUIGraphics.BrushType.SOLID_COLOR or ScriptUIGraphics.BrushType.THEME_COLOR
-	 */
-	readonly type: number;
-
-}
-
-/**
- * A helper object that encapsulates a drawing path for a figure to be drawn into a window or control.
- * Create with the newPath(), moveto(), lineto(), rectPath(), and ellipsePath() methods.Used as value of currentPath, where it is acted upon by methods such as closePath().Pass as optional argument to fillPath() and strokePath(), which otherwise act upon the current path.
- */
-declare class ScriptUIPath {
-}
-
-/**
- * An object used to draw custom graphics, found in the graphics property of window, container, and control objects.
- * Allows a script to customize aspects of the element’s appearance, such as the color and font. Use an onDraw callback function to set these properties or call the functions.All measurements are in pixels.
- */
-declare class ScriptUIGraphics {
-	/**
-	 * Contains the enumerated constants for the type argument of newBrush().
-	 * Type constants are: SOLID_COLOR, THEME_COLOR.
-	 */
-	static readonly BrushType: Object;
-
-	/**
-	 * Contains the enumerated constants for the type argument of newPen().
-	 * Type constants are: SOLID_COLOR, THEME_COLOR.
-	 */
-	static readonly PenType: Object;
-
-	/**
-	 * The background color for containers; for non-containers, the parent background color.
-	 * The paint color and style is defined in this brush object.This property is only supported for controls likedropdownlist, edittext, and listbox.
-	 */
-	backgroundColor: ScriptUIBrush;
-
-	/**
-	 * The current drawing path, encapsulated in a path object.
-	 */
-	readonly currentPath: ScriptUIPath;
-
-	/**
-	 * The current position in the current drawing path.
-	 */
-	readonly currentPoint: Point;
-
-	/**
-	 * The background color for containers when disabled or inactive; for non-containers, the parent background color.
-	 * The paint color and style is defined in this brush object.This property is only supported for controls likedropdownlist, edittext, and listbox.
-	 */
-	disabledBackgroundColor: ScriptUIBrush;
-
-	/**
-	 * The text color when the element is disabled or inactive.
-	 * The paint color and style is defined in this pen object.
-	 */
-	disabledForegroundColor: ScriptUIPen;
-
-	/**
-	 * The default font to use for displaying text.
-	 */
-	font: ScriptUIFont;
-
-	/**
-	 * The text color.
-	 * The paint color and style is defined in this pen object.
-	 */
-	foregroundColor: ScriptUIPen;
-
-	/**
-	 * Closes the current path.
-	 * Defines a line from the current postion (currentPoint) to the start point of the current path (the value of currentPath).
-	 */
-	closePath(): void;
-
-	/**
-	 * Draws a focus ring within a region of this element.
-	 * @param left The left coordinate of the region. Value is relative to the origin of this element.
-	 * @param top The top coordinate of the region. Value is relative to the origin of this element.
-	 * @param width The width of the region in pixels.
-	 * @param height The height of the region in pixels.
-	 */
-	drawFocusRing(left: number, top: number, width: number, height: number): void;
-
-	/**
-	 * Draws an image within a given region of the element.
-	 * Uses the version of the image that is appropriate to the element's current state.
-	 * @param image The image to draw. This object contains different versions of an image appropriate to various element states, such as a dimmed version for the disabled state.
-	 * @param left The left coordinate of the region, relative to the origin of this element.
-	 * @param top The top coordinate of the region, relative to the origin of this element.
-	 * @param width The width in pixels. If provided, the image is stretched or shrunk to fit. If omitted, uses the original image width.
-	 * @param height The height in pixels. If provided, the image is stretched or shrunk to fit. If omitted, uses the original image height.
-	 */
-	drawImage(image: ScriptUIImage, left: number, top: number, width?: number, height?: number): void;
-
-	/**
-	 * Draw the platform-specific control associated with this element.
-	 */
-	drawOSControl(): void;
-
-	/**
-	 * Draw a string of text starting at a given point in this element, using a given drawing pen and font.
-	 * @param text The text string.
-	 * @param pen The drawing pen to use.
-	 * @param x The left coordinate, relative to the origin of this element.
-	 * @param y The top coordinate, relative to the origin of this element.
-	 * @param font The font to use. Default is the  font value in this object.
-	 */
-	drawString(text: string, pen: ScriptUIPen, x: number, y: number, font?: ScriptUIFont): void;
-
-	/**
-	 * Defines an elliptical path within a given rectangular area in the currentPath object, which can be filled using fillPath() or stroked using strokePath().
-	 * Returns a Point object for the upper left corner of the area, which is the new currentPoint.
-	 * @param left The left coordinate of the region, relative to the origin of this element.
-	 * @param top The top coordinate of the region, relative to the origin of this element.
-	 * @param width The width of the region in pixels.
-	 * @param height The height of the region in pixels.
-	 */
-	ellipsePath(left: number, top: number, width: number, height: number): Point;
-
-	/**
-	 * Fills a path using a given painting brush.
-	 * @param brush The brush object that defines the fill color.
-	 * @param path The path object. Default is the currentPath.
-	 */
-	fillPath(brush: ScriptUIBrush, path?: ScriptUIPath): void;
-
-	/**
-	 * Adds a path segment to the currentPath.
-	 * The line is defined from the currentPoint to the specified destination point. Returns the Point objectfor the destination point, which becomes the new value of currentPoint.
-	 * @param x The X coordinate for the destination point, relative to the origin of this element.
-	 * @param y The Y coordinate for the destination point, relative to the origin of this element.
-	 */
-	lineTo(x: number, y: number): Point;
-
-	/**
-	 * Calculates the size needed to display a string using the given font.
-	 * Returns a Dimension object that contains the height and width of the string in pixels.
-	 * @param text The text string to measure.
-	 * @param font The font to use. Default is the font value in this object.
-	 * @param boundingWidth The bounding width.
-	 */
-	measureString(text: string, font?: ScriptUIFont, boundingWidth?: number): Dimension;
-
-	/**
-	 * Adds a given point to the currentPath, and makes it the current drawing position.
-	 * Returns the Point object which is the new value of currentPoint.
-	 * @param x The X coordinate for the new point, relative to the origin of this element.
-	 * @param y The Y coordinate for the new point, relative to the origin of this element.
-	 */
-	moveTo(x: number, y: number): Point;
-
-	/**
-	 * Creates a new painting brush object.
-	 * @param type The brush type, solid or theme. One of the constants ScriptUIGraphics.BrushType.SOLID_COLOR or ScriptUIGraphics.BrushType.THEME_COLOR.
-	 * @param color The brush color. If type is SOLID_COLOR, the color expressed as an array of three or four values, in the form [R, B, G, A] specifying the red, green, and blue values of the color and, optionally, the opacity (alpha channel). All values are numbers in the range [0.0..1.0]. An opacity of 0 is fully transparent, and an opacity of 1 is fully opaque. If the type is THEME_COLOR, the name string of the theme. Theme colors are defined by the host application.
-	 */
-	newBrush(type: number, color: number[]): ScriptUIBrush;
-
-	/**
-	 * Creates a new, empty path object.
-	 * Replaces any existing path in currentPath.
-	 */
-	newPath(): ScriptUIPath;
-
-	/**
-	 * Creates a new drawing pen object.
-	 * @param type The pen type, solid or theme. One of the constants ScriptUIGraphics.PenType.SOLID_COLOR or ScriptUIGraphics.PenType.THEME_COLOR.
-	 * @param color The pen color. If type is SOLID_COLOR, the color expressed as an array of three or four values, in the form [R, B, G, A] specifying the red, green, and blue values of the color and, optionally, the opacity (alpha channel). All values are numbers in the range [0.0..1.0]. An opacity of 0 is fully transparent, and an opacity of 1 is fully opaque. If the type is THEME_COLOR, the name string of the theme. Theme colors are defined by the host application.
-	 * @param width The width of the pen line in pixels. The line is centered around the current point. For example, if the value is 2, drawing a line from (0, 10) to (5, 10) paints the two rows of pixels directly above and below y-position 10.
-	 */
-	newPen(type: number, color: number[], width: number): ScriptUIPen;
-
-	/**
-	 * Defines a rectangular path in the currentPath object.
-	 * The rectangle can be filled using fillPath() or stroked using strokePath().Returns the Point objectfor the upper left corner of the rectangle, which becomes the new value of currentPoint.
-	 * @param left The left coordinate relative to the origin of this element.
-	 * @param top The top coordinate relative to the origin of this element.
-	 * @param width The width in pixels.
-	 * @param height The height in pixels.
-	 */
-	rectPath(left: number, top: number, width: number, height: number): Point;
-
-	/**
-	 * Strokes the path segments of a path with a given drawing pen.
-	 * @param pen The drawing pen that defines the color and line width.
-	 * @param path The path object. Default is the currentPath.
-	 */
-	strokePath(pen: ScriptUIPen, path?: ScriptUIPath): void;
-
-}
-
-/**
- * Describes an input state at the time of the triggering  ScriptUIGraphics.onDraw() event.
- * Contains properties that report whether the current control has the input focus, and the particular mouse button and keypress state. Passed in as argument to ScriptUIGraphics.onDraw().
- */
-declare class DrawState {
-	/**
-	 * True if the Alt key is being pressed (in Windows only).
-	 */
-	readonly altKeyPressed: boolean;
-
-	/**
-	 * True if the Caps Lock key is being pressed.
-	 */
-	readonly capsLockKeyPressed: boolean;
-
-	/**
-	 * True if the Command key is being pressed (in Mac OS only).
-	 */
-	readonly cmdKeyPressed: boolean;
-
-	/**
-	 * True if the Ctrl key is being pressed.
-	 */
-	readonly ctrlKeyPressed: boolean;
-
-	/**
-	 * True if the element has the input focus.
-	 */
-	readonly hasFocus: boolean;
-
-	/**
-	 * True if the left mouse button is being pressed.
-	 */
-	readonly leftButtonPressed: boolean;
-
-	/**
-	 * True if the middle mouse button is being pressed.
-	 */
-	readonly middleButtonPressed: boolean;
-
-	/**
-	 * True if the cursor is hovering over this element.
-	 */
-	readonly mouseOver: boolean;
-
-	/**
-	 * True if the Num Lock key is being pressed.
-	 */
-	readonly numLockKeyPressed: boolean;
-
-	/**
-	 * True if the Option key is being pressed (in Mac OS only).
-	 */
-	readonly optKeyPressed: boolean;
-
-	/**
-	 * True if the right mouse button is being pressed.
-	 */
-	readonly rightButtonPressed: boolean;
-
-	/**
-	 * True if the Shift key is being pressed.
-	 */
-	readonly shiftKeyPressed: boolean;
-
-}
-
-/**
- * Encapsulates the qualities of a font used to draw text into a control.
- * Create with the newFont() method.Used as a value of font. Passed as an argument to drawString() and measureString().
- */
-declare class ScriptUIFont {
-	/**
-	 * The font family name.
-	 */
-	readonly family: string;
-
-	/**
-	 * The complete font name, consisting of the family and style, if specified.
-	 */
-	readonly name: string;
-
-	/**
-	 * The font point size.
-	 */
-	readonly size: number;
-
-	/**
-	 * The font style. One of the constants in ScriptUIGraphics.FontStyle.
-	 */
-	readonly style: Object;
-
-	/**
-	 * The name of a substitution font, a fallback font to substitute for this font if the requested font family or style is not available.
-	 */
-	readonly substitute: string;
-
-}
-
-/**
- * Encapsulates a set of images that can be drawn into a control.
- * Different images can reflect the current state, such as a dimmed version for a disabled control. Create with the newImage() method. Passed as an argument to drawImage().
- */
-declare class ScriptUIImage {
-	/**
-	 * The image format. One of: resource, JPEG, GIF, TIFF, PNG, or PICT (Macintosh).
-	 */
-	readonly format: string;
-
-	/**
-	 * The image name. Either the file name, or the resource name.
-	 */
-	readonly name: string;
-
-	/**
-	 * The full path to the file that contains the image.
-	 */
-	readonly pathname: string;
-
-	/**
-	 * The image size in pixels.
-	 */
-	readonly size: Dimension;
-
-}
-
-/**
- * A text label that the user cannot change.
- */
-declare class StaticText {
-	/**
-	 * Always false. This element cannot have input focus.
-	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
-	 */
-	active: boolean;
-
-	/**
-	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
-
-	/**
-	 * The boundaries of the element, in parent-relative coordinates.
-	 * Setting an element's size or location changes its bounds property, and vice-versa.
-	 */
-	bounds: Bounds;
-
-	/**
-	 * A number of characters for which to reserve space when calculating the preferred size of the element.
-	 */
-	characters: number;
-
-	/**
-	 * An array of child elements.
-	 */
-	readonly children: Object[];
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
-	 */
-	readonly graphics: ScriptUIGraphics;
-
-	/**
-	 * The help text that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The number of pixels to indent the element during automatic layout.
-	 * Applies for column orientation and left alignment, or row orientation and top alignment.
-	 */
-	indent: number;
-
-	/**
-	 * The text justification style.
-	 * One of left, center, or right. Justification only works if this value is set on creation of the element.
-	 */
-	justify: string;
-
-	/**
-	 * The upper left corner of this element relative to its parent.
-	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
-	 */
-	location: Point;
-
-	/**
-	 * The maximum height and width to which the element can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * The minimum height and width to which the element can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size, used by layout managers to determine the best size for each element.
-	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
-	 * Creation properties of a StaticText object can include:
-	 * multiline: When false (the default), the control displays a single line of text. When true, the control displays multiple lines, in which case the text wraps within the width of the control.
-	 * scrolling: When false (the default), the displayed text cannot be scrolled. When true, the displayed text can be vertically scrolled using the Up Arrow and Down Arrow; this case implies multiline=true.
-	 */
-	properties: Object;
-
-	/**
-	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
-	 */
-	shortcutKey: string;
-
-	/**
-	 * The current dimensions of this element.
-	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
-	 */
-	size: Dimension;
-
-	/**
-	 * The text to display, a localizable string.
-	 */
-	text: string;
-
-	/**
-	 * The element type, "statictext".
-	 */
-	readonly type: string;
-
-	/**
-	 * True if this element is shown, false if it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this element relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this element.
-	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): Event;
-
-	/**
-	 * Hides this element.
-	 */
-	hide(): void;
-
-	/**
-	 * Sends a notification message, simulating the specified user interaction event.
-	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
-	 */
-	notify(eventName?: string): void;
-
-	/**
-	 * An event-handler callback function, called when the window is about to be drawn.
-	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
-	 */
-	onDraw(): void;
-
-	/**
-	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
-	 * In Windows only.
-	 */
-	onShortcutKey(): void;
-
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this element.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Shows this element.
-	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
-	 */
-	show(): void;
-
-}
-
-/**
- * A pushbutton element containing a mouse-sensitive text string.
- * Calls the onClick() callback if the control is clicked or if its notify() method is called.
- */
-declare class Button {
-	/**
-	 * True if this element is active.
-	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
-	 */
-	active: boolean;
-
-	/**
-	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
-
-	/**
-	 * The boundaries of the element, in parent-relative coordinates.
-	 * Setting an element's size or location changes its bounds property, and vice-versa.
-	 */
-	bounds: Bounds;
-
-	/**
-	 * A number of characters for which to reserve space when calculating the preferred size of the element.
-	 */
-	characters: number;
-
-	/**
-	 * An array of child elements.
-	 */
-	readonly children: Object[];
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
-	 */
-	readonly graphics: ScriptUIGraphics;
-
-	/**
-	 * The help string that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The number of pixels to indent the element during automatic layout.
-	 * Applies for column orientation and left alignment, or row orientation and top alignment.
-	 */
-	indent: number;
-
-	/**
-	 * The text justification style.
-	 * One of left, center, or right. Justification only works if this value is set on creation of the element.
-	 */
-	justify: string;
-
-	/**
-	 * The upper left corner of this element relative to its parent.
-	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
-	 */
-	location: Point;
-
-	/**
-	 * The maximum height and width to which the element can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * The minimum height and width to which the element can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size, used by layout managers to determine the best size for each element.
-	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
-	 * A Button object has no creation properties, but the third argument to the add() method that creates it can be the initial text value.
-	 */
-	properties: Object;
-
-	/**
-	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
-	 */
-	shortcutKey: string;
-
-	/**
-	 * The current dimensions of this element.
-	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
-	 */
-	size: Dimension;
-
-	/**
-	 * The text to display, a localizable string.
-	 */
-	text: string;
-
-	/**
-	 * The element type; "button".
-	 */
-	readonly type: string;
-
-	/**
-	 * True if this element is shown, false if it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this element relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this element.
-	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): Event;
-
-	/**
-	 * Hides this element.
-	 */
-	hide(): void;
-
-	/**
-	 * Sends a notification message, simulating the specified user interaction event.
-	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
-	 */
-	notify(eventName?: string): void;
-
-	/**
-	 * An event-handler callback function, called when the element acquires the keyboard focus.
-	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
-	 */
-	onActivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the element has been clicked
-	 */
-	onClick(): void;
-
-	/**
-	 * An event-handler callback function, called when the element loses the keyboard focus.
-	 * Called when the user moves the keyboard focus from the previously active control to another control.
-	 */
-	onDeactivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the window is about to be drawn.
-	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
-	 */
-	onDraw(): void;
-
-	/**
-	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
-	 * In Windows only.
-	 */
-	onShortcutKey(): void;
-
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this element.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Shows this element.
-	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
-	 */
-	show(): void;
-
-}
-
-/**
- * Amouse-sensitive pushbutton that displays an image instead of text.
- * Calls the onClick() callback if the control is clicked or if its notify() method is called.
- */
-declare class IconButton {
-	/**
-	 * True if this element is active.
-	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
-	 */
-	active: boolean;
-
-	/**
-	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
-
-	/**
-	 * The boundaries of the element, in parent-relative coordinates.
-	 * Setting an element's size or location changes its bounds property, and vice-versa.
-	 */
-	bounds: Bounds;
-
-	/**
-	 * An array of child elements.
-	 */
-	readonly children: Object[];
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
-	 */
-	readonly graphics: ScriptUIGraphics;
-
-	/**
-	 * The help text that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The image object that defines the image to be drawn.
-	 */
-	image: ScriptUIImage;
-
-	/**
-	 * The number of pixels to indent the element during automatic layout.
-	 * Applies for column orientation and left alignment, or row orientation and top alignment.
-	 */
-	indent: number;
-
-	/**
-	 * The upper left corner of this element relative to its parent.
-	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
-	 */
-	location: Point;
-
-	/**
-	 * The maximum height and width to which the element can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * The minimum height and width to which the element can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size, used by layout managers to determine the best size for each element.
-	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
-	 * Creation properties of an IconButton object can include:
-	 * style:A string for the visual style, either "button", which has a visible border with a raised or 3D appearance, or "toolbutton", which has a flat appearance, appropriate for inclusion in a toolbar.
-	 */
-	properties: Object;
-
-	/**
-	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
-	 */
-	shortcutKey: string;
-
-	/**
-	 * The current dimensions of this element.
-	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
-	 */
-	size: Dimension;
-
-	/**
-	 * The element type; "iconbutton".
-	 */
-	readonly type: string;
-
-	/**
-	 * True if this element is shown, false if it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this element relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this element.
-	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): Event;
-
-	/**
-	 * Hides this element.
-	 */
-	hide(): void;
-
-	/**
-	 * Sends a notification message, simulating the specified user interaction event.
-	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
-	 */
-	notify(eventName?: string): void;
-
-	/**
-	 * An event-handler callback function, called when the element acquires the keyboard focus.
-	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
-	 */
-	onActivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the element has been clicked.
-	 */
-	onClick(): void;
-
-	/**
-	 * An event-handler callback function, called when the element loses the keyboard focus.
-	 * Called when the user moves the keyboard focus from the previously active control to another control.
-	 */
-	onDeactivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the window is about to be drawn.
-	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
-	 */
-	onDraw(): void;
-
-	/**
-	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
-	 * In Windows only.
-	 */
-	onShortcutKey(): void;
-
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this element.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Shows this element.
-	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
-	 */
-	show(): void;
-
-}
-
-/**
- * An editable text field that the user can select and change.
- * Calls the onChange() callback if the text is changed and the user types Enter or the control loses focus, or if its notify() method is called. Calls the onChanging() callback when any change is made to the text. The textselection property contains currently selected text.
- */
-declare class EditText {
-	/**
-	 * True if this element is active.
-	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
-	 */
-	active: boolean;
-
-	/**
-	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
-
-	/**
-	 * The boundaries of the element, in parent-relative coordinates.
-	 * Setting an element's size or location changes its bounds property, and vice-versa.
-	 */
-	bounds: Bounds;
-
-	/**
-	 * A number of characters for which to reserve space when calculating the preferred size of the element.
-	 */
-	characters: number;
-
-	/**
-	 * An array of child elements.
-	 */
-	readonly children: Object[];
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
-	 */
-	readonly graphics: ScriptUIGraphics;
-
-	/**
-	 * The help text that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The number of pixels to indent the element during automatic layout.
-	 * Applies for column orientation and left alignment, or row orientation and top alignment.
-	 */
-	indent: number;
-
-	/**
-	 * The text justification style.
-	 * One of left, center, or right. Justification only works if this value is set on creation of the element.
-	 */
-	justify: string;
-
-	/**
-	 * The upper left corner of this element relative to its parent.
-	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
-	 */
-	location: Point;
-
-	/**
-	 * The maximum height and width to which the element can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * The minimum height and width to which the element can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size, used by layout managers to determine the best size for each element.
-	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
-	 * Creation properties of an EditText object can include:
-	 * multiline: When false (the default), the control displays a single line of text. When true, the control displays multiple lines, in which case the text wraps within the width of the control.
-	 * readonly: When false (the default),the control accepts text input. When true, the control does not accept input but only displays the contents of the text property.
-	 * noecho: When false (the default), the control displays input text. When true, the control does not display input text (used for password input fields).
-	 * enterKeySignalsOnChange: When false (the default), the control signals an onChange event when the editable text is changed and the control loses the keyboard focus (that is, the user tabs to another control, clicks outside the control, or types Enter). When true, the control only signals an onChange() event when the editable text is changed and the user types Enter; other changes to the keyboard focus do not signal the event.
-	 * wantReturn: Only applies to multiple line edit controls in ScriptUI Version 6.0 or later. When true the RETURN/ENTER keystroke is considered as text-input advancing the cursor to the next line. The default value is false.
-	 */
-	properties: Object;
-
-	/**
-	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
-	 */
-	shortcutKey: string;
-
-	/**
-	 * The current dimensions of this element.
-	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
-	 */
-	size: Dimension;
-
-	/**
-	 * The current text displayed in the field, a localizable string.
-	 */
-	text: string;
-
-	/**
-	 * The currently selected text, or the empty string if there is no text selected.
-	 * Setting the value replaces the current text selection and modifies the value of the text property. If there is no current selection, inserts the new value into the text string at the current insertion point. The textselection value is reset to an empty string after it modifies the text value. Note that setting the textselection property before the element’s parent Window exists is an undefined operation.
-	 */
-	textselection: string;
-
-	/**
-	 * The element type; "edittext".
-	 */
-	readonly type: string;
-
-	/**
-	 * True if this element is shown, false if it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this element relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this element.
-	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): Event;
-
-	/**
-	 * Hides this element.
-	 */
-	hide(): void;
-
-	/**
-	 * Sends a notification message, simulating the specified user interaction event.
-	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
-	 */
-	notify(eventName?: string): void;
-
-	/**
-	 * An event-handler callback function, called when the element acquires the keyboard focus.
-	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
-	 */
-	onActivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the content of the element has been changed
-	 * The handler is called only when the change is complete—that is, when focus moves to another control, or the user types Enter. The exact behavior depends on the creation parameter enterKeySignalsOnChange;see the properties property.
-	 */
-	onChange(): void;
-
-	/**
-	 * An event-handler callback function, called when the content of the element is in the process of changing
-	 * The handler is called for each keypress while this control has the input focus.
-	 */
-	onChanging(): void;
-
-	/**
-	 * An event-handler callback function, called when the element loses the keyboard focus.
-	 * Called when the user moves the keyboard focus from the previously active control to another control.
-	 */
-	onDeactivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the window is about to be drawn.
-	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
-	 */
-	onDraw(): void;
-
-	/**
-	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
-	 * In Windows only.
-	 */
-	onShortcutKey(): void;
-
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this element.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Shows this element.
-	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
-	 */
-	show(): void;
-
-}
-
-/**
- * Displays a list of choices, represented by ListItem objects.
- * When you create the object, you specify whether it allows the user to select only one or multiple items. If a list contains more items than can be displayed in the available area, a scrollbar may appear that allows the user to scroll through all the list items.You can specify the items on creation of the list object, or afterward using the list object’s add() method. You can remove items programmatically with the list object’s remove() and removeAll() methods. You can create a list box with multiple columns; in this case, each row is a selectable choice, and each ListItem represents one row.
- */
-declare class ListBox {
-	/**
-	 * True if this element is active.
-	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
-	 */
-	active: boolean;
-
-	/**
-	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
-
-	/**
-	 * The boundaries of the element, in parent-relative coordinates.
-	 * Setting an element's size or location changes its bounds property, and vice-versa.
-	 */
-	bounds: Bounds;
-
-	/**
-	 * An array of child ListItem elements.
-	 */
-	readonly children: Object[];
-
-	/**
-	 * For a multi-column list box, the column properties.
-	 * A JavaScript object with two read-only properties whose values are set by the creation parameters:
-	 * titles: An array of column title strings, whose length matches the number of columns specified at creation.
-	 * preferredWidths: An array of column widths, whose length matches the number of columns specified at creation.
-	 * visible: An array of boolean visible attributes, whose length matches the number of columns specified at creation.This property can be used to show/hide a column. Avaiblable in ScriptUI Version 6.0 or later provided ScriptUI.frameworkName == 'Flex'.
-	 */
-	readonly columns: Object;
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
-	 */
-	readonly graphics: ScriptUIGraphics;
-
-	/**
-	 * The help text that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The number of pixels to indent the element during automatic layout.
-	 * Applies for column orientation and left alignment, or row orientation and top alignment.
-	 */
-	indent: number;
-
-	/**
-	 * The width and height in pixels of each item in the list.
-	 * Used by auto-layout to determine the preferredSize of the list, if not otherwise specified. If not set explicitly, the size of each item is set to match the largest height and width among all items in the list
-	 */
-	itemSize: Dimension;
-
-	/**
-	 * The array of choice items displayed in the list.
-	 * Access this array with a 0-based index. To obtain the number of items in the list, use items.length.The objects are created when items are specified on creation of the parent list object, or afterward using the list control’s add() method. Each item has a selected property that is true when it is in the selected state.
-	 */
-	readonly items: ListItem[];
-
-	/**
-	 * The upper left corner of this element relative to its parent.
-	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
-	 */
-	location: Point;
-
-	/**
-	 * The maximum height and width to which the element can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * The minimum height and width to which the element can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size, used by layout managers to determine the best size for each element.
-	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the control (properties used only when the element is created).
-	 * Creation properties of a ListBox object can include:
-	 * multiselect: When false (the default), only one item can be selected. When true, multiple items can be selected.
-	 * items: An array of strings for the text of each list item. An item object is created for each item. An item with the text string "-" creates a separator item. Supply this property, or the items argument to the add() method, not both. This form is most useful for elements defined using Resource Specifications.
-	 * numberOfColumns: A number of columns in which to display the items; default is 1. When there are multiple columns, each ListItem object represents a selectable row. Its text and image values specify the label in the first column, and the subitems property specifies the labels in the additional columns.
-	 * showHeaders: True to display column titles.
-	 * columnWidths: An array of numbers for the preferred width in pixels of each column.
-	 * columnTitles: A corresponding array of strings for the title of each column, to be shown if showHeaders is true.
-	 */
-	properties: Object;
-
-	/**
-	 * The currently selected item for a single-selection list, or an array of items for current selection in a multi-selection list.
-	 * Setting this value causes the selected item to be highlighted and to be scrolled into view if necessary. If no items are selected, the value is null. Set to null to deselect all items. You can set the value using the index of an item or an array of indices, rather than object references. If set to an index value that is out of range, the operation is ignored. When set with index values, the property still returns object references.
-	 * If you set the value to an array for a single-selection list, only the first item in the array is selected.
-	 * If you set the value to a single item for a multi-selection list, that item is added to the current selection.
-	 */
-	selection: ListItem;
-
-	/**
-	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
-	 */
-	shortcutKey: string;
-
-	/**
-	 * The current dimensions of this element.
-	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
-	 */
-	size: Dimension;
-
-	/**
-	 * The element type; "listbox".
-	 */
-	readonly type: string;
-
-	/**
-	 * True if this element is shown, false if it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this element relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Adds an item to the choices in this list.
-	 * Returns the item control object. If this is a multi-column list box, each added ListItem represents one selectable row.Its text and image values specify the label in the first column, and the subitems property specifies the labels in the additional columns.
-	 * @param type The type of the child element, the string "item".
-	 * @param text The localizable text label for the item.
-	 */
-	add(type: string, text?: string): ListItem;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this element.
-	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): Event;
-
-	/**
-	 * Retrieves an item object from the list that has a given text label.
-	 * @param text The text string to match.
-	 */
-	find(text: string): ListItem;
-
-	/**
-	 * Hides this element.
-	 */
-	hide(): void;
-
-	/**
-	 * Sends a notification message, simulating the specified user interaction event.
-	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
-	 */
-	notify(eventName?: string): void;
-
-	/**
-	 * An event-handler callback function, called when the element acquires the keyboard focus.
-	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
-	 */
-	onActivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the content of the element has been changed
-	 */
-	onChange(): void;
-
-	/**
-	 * An event-handler callback function, called when the element loses the keyboard focus.
-	 * Called when the user moves the keyboard focus from the previously active control to another control.
-	 */
-	onDeactivate(): void;
-
-	/**
-	 * An event-handler callback function, called when an item in the listbox is double-clicked
-	 * Check the selection property to identify the item that was double-clicked.
-	 */
-	onDoubleClick(): void;
-
-	/**
-	 * An event-handler callback function, called when the window is about to be drawn.
-	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
-	 */
-	onDraw(): void;
-
-	/**
-	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
-	 * In Windows only.
-	 */
-	onShortcutKey(): void;
-
-	/**
-	 * Removes a child item from the list.
-	 * @param what The item or child to remove, specified by 0-based index, text value, or as a ListItem object.
-	 */
-	remove(what: any): void;
-
-	/**
-	 * Removes all child items from the list.
-	 */
-	removeAll(): void;
-
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this element.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Shows this element.
-	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
-	 */
-	show(): void;
-
-}
-
-/**
- * Displays a single visible item. When you click the control, a list drops down or pops up, and allows you to select one of the other items in the list.
- * Drop-down lists can have nonselectable separator items for visually separating groups of related items, as in a menu. You can specify the items on creation of the list object, or afterward using the list object’s add() method. You can remove items programmatically with the list object’s remove() and removeAll() methods. Calls the onChange() callback if the item selection is changed or if its notify() method is called.
- */
-declare class DropDownList {
-	/**
-	 * True if this element is active.
-	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
-	 */
-	active: boolean;
-
-	/**
-	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
-
-	/**
-	 * The boundaries of the element, in parent-relative coordinates.
-	 * Setting an element's size or location changes its bounds property, and vice-versa.
-	 */
-	bounds: Bounds;
-
-	/**
-	 * An array of child elements.
-	 */
-	readonly children: Object[];
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
-	 */
-	readonly graphics: ScriptUIGraphics;
-
-	/**
-	 * The help text that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The number of pixels to indent the element during automatic layout.
-	 * Applies for column orientation and left alignment, or row orientation and top alignment.
-	 */
-	indent: number;
-
-	/**
-	 * The width and height in pixels of each item in the list.
-	 * Used by auto-layout to determine the preferredSize of the list, if not otherwise specified. If not set explicitly, the size of each item is set to match the largest height and width among all items in the list
-	 */
-	itemSize: Dimension;
-
-	/**
-	 * The array of choice items displayed in the drop-down or pop-up list.
-	 * Access this array with a 0-based index. To obtain the number of items in the list, use items.length.The objects are created when items are specified on creation of the parent list object, or afterward using the list control’s add() method. Items in a drop-down list can be of type separator, in which case they cannot be selected, and are shown as a horizontal line. Each item has a selected property that is true when it is in the selected state.
-	 */
-	readonly items: ListItem[];
-
-	/**
-	 * The upper left corner of this element relative to its parent.
-	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
-	 */
-	location: Point;
-
-	/**
-	 * The maximum height and width to which the element can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * The minimum height and width to which the element can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size, used by layout managers to determine the best size for each element.
-	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
-	 * Creation properties of a DropDownList object can include:
-	 * items: An array of strings for the text of each list item. An item object is created for each item. An item with the text string "-" creates a separator item. Supply this property, or the items argument to the add() method, not both. This form is most useful for elements defined using Resource Specifications.
-	 */
-	properties: Object;
-
-	/**
-	 * The currently selectedlist item.
-	 * Setting this value causes the selected item to be highlighted and to be scrolled into view if necessary. If no items are selected, the value is null. Set to null to deselect all items.You can set the value using the index of an item, rather than an object reference. If set to an index value that is out of range, the operation is ignored. When set with an index value, the property still returns an object reference.
-	 */
-	selection: ListItem;
-
-	/**
-	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
-	 */
-	shortcutKey: string;
-
-	/**
-	 * The current dimensions of this element.
-	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
-	 */
-	size: Dimension;
-
-	/**
-	 * The element type; "dropdownlist".
-	 */
-	readonly type: string;
-
-	/**
-	 * True if this element is shown, false if it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this element relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Adds an item or separator to the choices in this list.
-	 * Returns the item control object for type="item", or null for type="separator".
-	 * @param type The type of the child element. Either item (a basic, selectable item with a text label) or separator
-	 * @param text The localizable text label for the item.
-	 */
-	add(type: string, text?: string): ListItem;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this element.
-	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): Event;
-
-	/**
-	 * Retrieves an item object from the list that has a given text label.
-	 * @param text The text string to match.
-	 */
-	find(text: string): ListItem;
-
-	/**
-	 * Hides this element.
-	 */
-	hide(): void;
-
-	/**
-	 * Sends a notification message, simulating the specified user interaction event.
-	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
-	 */
-	notify(eventName?: string): void;
-
-	/**
-	 * An event-handler callback function, called when the element acquires the keyboard focus.
-	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
-	 */
-	onActivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the content of the element has been changed
-	 */
-	onChange(): void;
-
-	/**
-	 * An event-handler callback function, called when the element loses the keyboard focus.
-	 * Called when the user moves the keyboard focus from the previously active control to another control.
-	 */
-	onDeactivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the window is about to be drawn.
-	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
-	 */
-	onDraw(): void;
-
-	/**
-	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
-	 * In Windows only.
-	 */
-	onShortcutKey(): void;
-
-	/**
-	 * Removes a child item from the list.
-	 * @param what The item or child to remove, specified by 0-based index, text value, or as a ListItem object.
-	 */
-	remove(what: any): void;
-
-	/**
-	 * Removes all child items from the list.
-	 */
-	removeAll(): void;
-
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this element.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Shows this element.
-	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
-	 */
-	show(): void;
-
-}
-
-/**
- * An item in a list box, drop-down list, or tree view.
- * You can specify initial items in the creation parameters when creating the parent list. Create new items using the add() method (ListBox.add(), DropDownList.add(), TreeView.add()) in the parent list with control type="item", or, for DropDownList controls, type="separator".For a multi-column list box, the object represents one selectable row. Its text and image values specify the label in the first column, and the subitems property specifies the labels in the additional columns.
- */
-declare class ListItem {
-	/**
-	 * The checked state of an item in a list.
-	 * When true, the item is marked with the platform-appropriate checkmark. When false, no checkmark is drawn, but space is reserved for it in the left margin, so that the item lines up with other checkable items. When undefined, no space is reserved for a checkmark.
-	 */
-	checked: boolean;
-
-	/**
-	 * The expansion state of an item of type node that is a child of a TreeView list control.
-	 * When true, the item is in the expanded state and its children are shown, when false, it is collapsed and children are hidden.
-	 */
-	expanded: boolean;
-
-	/**
-	 * An image object for an icon to display in the item.
-	 * When specified, the image appropriate to the selections state is drawn to the left of the text label. If the parent is a multi-column list box, this describes the label in the first column. Labels in additional columns are described by the subitems property.
-	 */
-	image: ScriptUIImage;
-
-	/**
-	 * The 0-based index of this item in the items collection of its parent list control.
-	 */
-	readonly index: number;
-
-	/**
-	 * The parent element, a list control.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * An object that contains one or more creation properties of the item (properties used only when the element is created).
-	 * A ListItem object has no creation properties.
-	 */
-	properties: Object;
-
-	/**
-	 * The selection state of this item.
-	 * When true, the item is part of the selection for its parent list. When false, the item is not selected. Set to true to select this item in a single-selection list, or to add it to the selection array for a multi-selection list.
-	 */
-	selected: boolean;
-
-	/**
-	 * When the parent is a multi-column ListBox, this describes the labels for this selectable row in additional columns.
-	 * A array of JavaScript objects whose length is one less than the number of columns. The first member describes the label in the second column. Each member object has two properties, of which you can specify one or both:
-	 * text: A display string for the corresponding label.
-	 * image: An ScriptUIImage object for the corresponding label.
-	 */
-	readonly subItems: any[];
-
-	/**
-	 * The label text to display for the item, a localizable string.
-	 * If the parent is a multi-column list box, this describes the label in the first column. Labels in additional columns are described by the subitems property.
-	 */
-	text: string;
-
-	/**
-	 * The element type.
-	 * Normally "item", but an item whose parent is a DropDownList control can have type "separator". A separator item is not mouse-sensitive and is drawn as a horizontal line across the drop-down or pop-up menu.
-	 */
-	readonly type: string;
-
-}
-
-/**
- * A dual-state control showing a box that has a checkmark when the value is true, and is empty when the value is false.
- * Calls the onClick() callback if the control is clicked or if its notify() method is called.
- */
-declare class Checkbox {
-	/**
-	 * True if this element is active.
-	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
-	 */
-	active: boolean;
-
-	/**
-	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
-
-	/**
-	 * The boundaries of the element, in parent-relative coordinates.
-	 * Setting an element's size or location changes its bounds property, and vice-versa.
-	 */
-	bounds: Bounds;
-
-	/**
-	 * A number of characters for which to reserve space when calculating the preferred size of the element.
-	 */
-	characters: number;
-
-	/**
-	 * An array of child elements.
-	 */
-	readonly children: Object[];
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
-	 */
-	readonly graphics: ScriptUIGraphics;
-
-	/**
-	 * The help text that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The number of pixels to indent the element during automatic layout.
-	 * Applies for column orientation and left alignment, or row orientation and top alignment.
-	 */
-	indent: number;
-
-	/**
-	 * The default text justification style for child text elements.
-	 * One of left, center, or right. Justification only works if this value is set on creation of the element.
-	 */
-	justify: string;
-
-	/**
-	 * The upper left corner of this element relative to its parent.
-	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
-	 */
-	location: Point;
-
-	/**
-	 * The maximum height and width to which the element can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * The minimum height and width to which the element can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size, used by layout managers to determine the best size for each element.
-	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the item (properties used only when the element is created).
-	 * A CheckBox object has no creation properties. The third argument to the add() method that creates it is the text to be displayed.
-	 */
-	properties: Object;
-
-	/**
-	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
-	 */
-	shortcutKey: string;
-
-	/**
-	 * The current dimensions of this element.
-	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
-	 */
-	size: Dimension;
-
-	/**
-	 * The text to display, a localizable string.
-	 */
-	text: string;
-
-	/**
-	 * The element type; "checkbox".
-	 */
-	readonly type: string;
-
-	/**
-	 * The selection state of the control.
-	 * When true, the control is in the selected or set state and displays the check mark. When false, shows an empty box.
-	 */
-	value: boolean;
-
-	/**
-	 * True if this element is shown, false if it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this element relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this element.
-	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): Event;
-
-	/**
-	 * Hides this element.
-	 */
-	hide(): void;
-
-	/**
-	 * Sends a notification message, simulating the specified user interaction event.
-	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
-	 */
-	notify(eventName?: string): void;
-
-	/**
-	 * An event-handler callback function, called when the element acquires the keyboard focus.
-	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
-	 */
-	onActivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the element has been clicked.
-	 */
-	onClick(): void;
-
-	/**
-	 * An event-handler callback function, called when the element loses the keyboard focus.
-	 * Called when the user moves the keyboard focus from the previously active control to another control.
-	 */
-	onDeactivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the window is about to be drawn.
-	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
-	 */
-	onDraw(): void;
-
-	/**
-	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
-	 * In Windows only.
-	 */
-	onShortcutKey(): void;
-
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this element.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Shows this element.
-	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
-	 */
-	show(): void;
-
-}
-
-/**
- * A scrollbar with a draggable scroll indicator and stepper buttons to move the indicator.
- * The scrollbar control has a horizontal orientation if the width is greater than the height at creation time, or vertical if its height is greater than its width.
- * Calls the onChange() callback after the position of the indicator is changed or if its notify() method is called. Calls the onChanging() callback repeatedly while the user is moving the indicator. Scrollbars are often created with an associated EditText field to display the current value of the scrollbar, and to allow setting the scrollbar's position to a specific value.
- */
-declare class Scrollbar {
-	/**
-	 * True if this element is active.
-	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
-	 */
-	active: boolean;
-
-	/**
-	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
-
-	/**
-	 * The boundaries of the element, in parent-relative coordinates.
-	 * Setting an element's size or location changes its bounds property, and vice-versa.
-	 */
-	bounds: Bounds;
-
-	/**
-	 * An array of child elements.
-	 */
-	readonly children: Object[];
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
-	 */
-	readonly graphics: ScriptUIGraphics;
-
-	/**
-	 * The help text that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The number of pixels to indent the element during automatic layout.
-	 * Applies for column orientation and left alignment, or row orientation and top alignment.
-	 */
-	indent: number;
-
-	/**
-	 * The amount to increment or decrement a scrollbar indicator's position when the user clicks ahead or behind the moveable element.
-	 * Default is 20% of the range between the maxvalue and minvalue property values.
-	 */
-	jumpdelta: number;
-
-	/**
-	 * The upper left corner of this element relative to its parent.
-	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
-	 */
-	location: Point;
-
-	/**
-	 * The maximum height and width to which the element can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * The maximum value allowed in the value property.
-	 * Together with minvalue, sets the scrolling range. Default is 100.
-	 */
-	maxvalue: number;
-
-	/**
-	 * The minimum height and width to which the element can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The minimum value allowed in the value property.
-	 * Together with  maxvalue, sets the scrolling range.Default is 0.
-	 */
-	minvalue: number;
-
-	/**
-	 * The parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size, used by layout managers to determine the best size for each element.
-	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
-	 * A Scrollbar object has no creation properties. The third argument of the add() method that creates it is the initial value, and the fourth and fifth arguments are the minimum and maximum values of the range.
-	 */
-	properties: Object;
-
-	/**
-	 * The key sequence that invokes the  onShortcutKey() callback for this element (in Windows only).
-	 */
-	shortcutKey: string;
-
-	/**
-	 * The current dimensions of this element.
-	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
-	 */
-	size: Dimension;
-
-	/**
-	 * The amount by which to increment or decrement a scrollbar element's position when the user clicks a stepper button.
-	 */
-	stepdelta: number;
-
-	/**
-	 * The element type, "scrollbar".
-	 */
-	readonly type: string;
-
-	/**
-	 * The current position of the indicator.
-	 * If set to a value outside the range specified by minvalue and maxvalue, it is automatically reset to the closest boundary.
-	 */
-	value: number;
-
-	/**
-	 * True if this element is shown, false if it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this element relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this element.
-	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): Event;
-
-	/**
-	 * Hides this element.
-	 */
-	hide(): void;
-
-	/**
-	 * Sends a notification message, simulating the specified user interaction event.
-	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
-	 */
-	notify(eventName?: string): void;
-
-	/**
-	 * An event-handler callback function, called when the element acquires the keyboard focus.
-	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
-	 */
-	onActivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the user has finished dragging the position indicator, or has clicked the control.
-	 */
-	onChange(): void;
-
-	/**
-	 * An event-handler callback function, called when the content of the element is in the process of changing
-	 * The handler is called for any motion of the position indicator while this control has the input focus.
-	 */
-	onChanging(): void;
-
-	/**
-	 * An event-handler callback function, called when the element loses the keyboard focus.
-	 * Called when the user moves the keyboard focus from the previously active control to another control.
-	 */
-	onDeactivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the window is about to be drawn.
-	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
-	 */
-	onDraw(): void;
-
-	/**
-	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
-	 * In Windows only.
-	 */
-	onShortcutKey(): void;
-
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this element.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Shows this element.
-	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
-	 */
-	show(): void;
-
-}
-
-/**
- * A dual-state control, grouped with other radiobuttons, of which only one can be in the selected state.
- * Shows the selected state when value=true, empty when value=false. Calls the onClick() callback if the control is clicked or if its notify() method is called.
- */
-declare class RadioButton {
-	/**
-	 * True if this element is active.
-	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
-	 */
-	active: boolean;
-
-	/**
-	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
-
-	/**
-	 * The boundaries of the element, in parent-relative coordinates.
-	 * Setting an element's size or location changes its bounds property, and vice-versa.
-	 */
-	bounds: Bounds;
-
-	/**
-	 * A number of characters for which to reserve space when calculating the preferred size of the element.
-	 */
-	characters: number;
-
-	/**
-	 * An array of child elements.
-	 */
-	readonly children: Object[];
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw event.
-	 */
-	readonly graphics: ScriptUIGraphics;
-
-	/**
-	 * The help text that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The number of pixels to indent the element during automatic layout.
-	 * Applies for column orientation and left alignment, or row orientation and top alignment.
-	 */
-	indent: number;
-
-	/**
-	 * The default text justification style for child text elements.
-	 * One of left, center, or right. Justification only works if this value is set on creation of the element.
-	 */
-	justify: string;
-
-	/**
-	 * The upper left corner of this element relative to its parent.
-	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
-	 */
-	location: Point;
-
-	/**
-	 * The maximum height and width to which the element can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * The minimum height and width to which the element can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size, used by layout managers to determine the best size for each element.
-	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes. A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
-	 * A RadioButton object has no creation properties. The third argument of the add() method that creates can be the label text.
-	 */
-	properties: Object;
-
-	/**
-	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
-	 */
-	shortcutKey: string;
-
-	/**
-	 * The current dimensions of this element.
-	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
-	 */
-	size: Dimension;
-
-	/**
-	 * The label text for this button, a localizable string.
-	 */
-	text: string;
-
-	/**
-	 * The element type; "radiobutton".
-	 */
-	readonly type: string;
-
-	/**
-	 * The selection state of this button, selected when true.
-	 */
-	value: boolean;
-
-	/**
-	 * True if this element is shown, false if it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this element relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this element.
-	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): Event;
-
-	/**
-	 * Hides this element.
-	 */
-	hide(): void;
-
-	/**
-	 * Sends a notification message, simulating the specified user interaction event.
-	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
-	 */
-	notify(eventName?: string): void;
-
-	/**
-	 * An event-handler callback function, called when the element acquires the keyboard focus.
-	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
-	 */
-	onActivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the element has been clicked.
-	 */
-	onClick(): void;
-
-	/**
-	 * An event-handler callback function, called when the element loses the keyboard focus.
-	 * Called when the user moves the keyboard focus from the previously active control to another control.
-	 */
-	onDeactivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the window is about to be drawn.
-	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
-	 */
-	onDraw(): void;
-
-	/**
-	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
-	 * In Windows only.
-	 */
-	onShortcutKey(): void;
-
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this element.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Shows this element.
-	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
-	 */
-	show(): void;
-
-}
-
-/**
- * A slider bar that indicates a numeric value with a moveable position indicator.
- * All slider controls have a horizontal orientation. Calls the onChange() callback after the position of the indicator is changed or if its notify() method is called. Calls the onChanging() callback repeatedly while the user is moving the indicator. The value property contains the current position of the indicator within the range of minvalue to maxvalue.
- */
-declare class Slider {
-	/**
-	 * True if this element is active.
-	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
-	 */
-	active: boolean;
-
-	/**
-	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
-
-	/**
-	 * The boundaries of the element, in parent-relative coordinates.
-	 * Setting an element's size or location changes its bounds property, and vice-versa.
-	 */
-	bounds: Bounds;
-
-	/**
-	 * An array of child elements.
-	 */
-	readonly children: Object[];
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
-	 */
-	readonly graphics: ScriptUIGraphics;
-
-	/**
-	 * The help text that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The number of pixels to indent the element during automatic layout.
-	 * Applies for column orientation and left alignment, or row orientation and top alignment.
-	 */
-	indent: number;
-
-	/**
-	 * The upper left corner of this element relative to its parent.
-	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
-	 */
-	location: Point;
-
-	/**
-	 * The maximum height and width to which the element can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * The maximum value allowed in the value property.
-	 * Together with minvalue, sets therange.Default is 100.
-	 */
-	maxvalue: number;
-
-	/**
-	 * The minimum height and width to which the element can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The minimum value allowed in the value property.
-	 * Together with maxvalue, sets the range.Default is 0.
-	 */
-	minvalue: number;
-
-	/**
-	 * The parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size, used by layout managers to determine the best size for each element.
-	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
-	 * A Slider object has no creation properties. The third argument of the add() method that creates it is the initial value, and the fourth and fifth arguments are the minimum and maximum values of the range.
-	 */
-	properties: Object;
-
-	/**
-	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
-	 */
-	shortcutKey: string;
-
-	/**
-	 * The current dimensions of this element.
-	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
-	 */
-	size: Dimension;
-
-	/**
-	 * The element type, "slider".
-	 */
-	readonly type: string;
-
-	/**
-	 * The current position of the indicator.
-	 * If set to a value outside the range specified by minvalue and maxvalue, it is automatically reset to the closest boundary.
-	 */
-	value: number;
-
-	/**
-	 * True if this element is shown, false if it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this element relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this element.
-	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): Event;
-
-	/**
-	 * Hides this element.
-	 */
-	hide(): void;
-
-	/**
-	 * Sends a notification message, simulating the specified user interaction event.
-	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
-	 */
-	notify(eventName?: string): void;
-
-	/**
-	 * An event-handler callback function, called when the element acquires the keyboard focus.
-	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
-	 */
-	onActivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the user has finished dragging the position indicator, or has clicked the control.
-	 */
-	onChange(): void;
-
-	/**
-	 * An event-handler callback function, called when the content of the element is in the process of changing
-	 * The handler is called for any motion of the position indicator while this control has the input focus.
-	 */
-	onChanging(): void;
-
-	/**
-	 * An event-handler callback function, called when the element loses the keyboard focus.
-	 * Called when the user moves the keyboard focus from the previously active control to another control.
-	 */
-	onDeactivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the window is about to be drawn.
-	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
-	 */
-	onDraw(): void;
-
-	/**
-	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
-	 * In Windows only.
-	 */
-	onShortcutKey(): void;
-
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this element.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Shows this element.
-	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
-	 */
-	show(): void;
 
 }
 
@@ -3249,838 +738,6 @@ declare class Progressbar {
 }
 
 /**
- * A hierarchical list whose items can contain child items.
- * The ListItem children of this control (in the items array) can be of type node, which means that they can contain child items. An item with child items can expanded, so that the child items are displayed, or collapsed, so that the child items are hidden Individual items can be selected at any level of the tree.
- */
-declare class TreeView {
-	/**
-	 * True if this element is active.
-	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
-	 */
-	active: boolean;
-
-	/**
-	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
-
-	/**
-	 * The boundaries of the element, in parent-relative coordinates.
-	 * Setting an element's size or location changes its bounds property, and vice-versa.
-	 */
-	bounds: Bounds;
-
-	/**
-	 * An array of child elements.
-	 */
-	readonly children: Object[];
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
-	 */
-	readonly graphics: ScriptUIGraphics;
-
-	/**
-	 * The help text that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The number of pixels to indent the element during automatic layout.
-	 * Applies for column orientation and left alignment, or row orientation and top alignment.
-	 */
-	indent: number;
-
-	/**
-	 * The width and height in pixels of each item in the list.
-	 * Used by auto-layout to determine the preferredSize of the list, if not otherwise specified. If not set explicitly, the size of each item is set to match the largest height and width among all items in the list
-	 */
-	itemSize: Dimension;
-
-	/**
-	 * The array of top-level items displayed in the list.
-	 * Access this array with a 0-based index. To obtain the number of items in the list, use items.length.The objects are created when items are specified on creation of the parent list object, or afterward using the list control’s add() method.
-	 */
-	readonly items: ListItem[];
-
-	/**
-	 * The upper left corner of this element relative to its parent.
-	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
-	 */
-	location: Point;
-
-	/**
-	 * The maximum height and width to which the element can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * The minimum height and width to which the element can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size, used by layout managers to determine the best size for each element.
-	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the control (properties used only when the element is created).
-	 * Creation properties of a ListBox object can include:
-	 * items: An array of strings for the text of each top-level list item. An item object is created for each item. An item with the text string "-" creates a separator item. Supply this property, or the items argument to the add() method, not both. This form is most useful for elements defined using Resource Specifications.
-	 */
-	properties: Object;
-
-	/**
-	 * The currently selectedlist item.
-	 * Setting this value causes the selected item to be highlighted and to be scrolled into view if necessary. If no items are selected, the value is null. Set to null to deselect all items.You can set the value using the index of an item, rather than an object reference. If set to an index value that is out of range, the operation is ignored. When set with an index value, the property still returns an object reference.
-	 */
-	selection: ListItem;
-
-	/**
-	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
-	 */
-	shortcutKey: string;
-
-	/**
-	 * The current dimensions of this element.
-	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
-	 */
-	size: Dimension;
-
-	/**
-	 * The element type, "treeview".
-	 */
-	readonly type: string;
-
-	/**
-	 * True if this element is shown, false if it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this element relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Adds an item to the top-level choices in this list.
-	 * Returns the item control object.
-	 * @param type The type of the child element, the string "item".
-	 * @param text The localizable text label for the item.
-	 */
-	add(type: string, text?: string): ListItem;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this element.
-	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): Event;
-
-	/**
-	 * Retrieves an item object from the list that has a given text label.
-	 * @param text The text string to match.
-	 */
-	find(text: string): ListItem;
-
-	/**
-	 * Hides this element.
-	 */
-	hide(): void;
-
-	/**
-	 * Sends a notification message, simulating the specified user interaction event.
-	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
-	 */
-	notify(eventName?: string): void;
-
-	/**
-	 * An event-handler callback function, called when the element acquires the keyboard focus.
-	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
-	 */
-	onActivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the content of the element has been changed
-	 */
-	onChange(): void;
-
-	/**
-	 * An event-handler callback function, called when the user collapses (closes) an expanded node in the treeview.
-	 * @param item The ListItem node that collapsed.
-	 */
-	onCollapse(item: ListItem): void;
-
-	/**
-	 * An event-handler callback function, called when the element loses the keyboard focus.
-	 * Called when the user moves the keyboard focus from the previously active control to another control.
-	 */
-	onDeactivate(): void;
-
-	/**
-	 * An event-handler callback function, called when the window is about to be drawn.
-	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
-	 */
-	onDraw(): void;
-
-	/**
-	 * An event-handler callback function, called when the user expands (opens) a collapsed node in the treeview.
-	 * @param item The ListItem node that expanded.
-	 */
-	onExpand(item: ListItem): void;
-
-	/**
-	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
-	 * In Windows only.
-	 */
-	onShortcutKey(): void;
-
-	/**
-	 * Removes a child item from the list.
-	 * @param what The item or child to remove, specified by 0-based index in the top-level item list, text value, or as a ListItem object.
-	 */
-	remove(what: any): void;
-
-	/**
-	 * Removes all child items from the list.
-	 */
-	removeAll(): void;
-
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this element.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Shows this element.
-	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
-	 */
-	show(): void;
-
-}
-
-/**
- * A control that contains a Flash Player, which can load and play Flash movies stored in SWF files.
- * The ScriptUI FlashPlayer element runs the Flash application within an Adobe application. The Flash application runs ActionScript, a different implementation of JavaScript from the ExtendScript version of JavaScript that Adobe applications run. A control object of this type contains functions that allow your script to load SWF files, control movie playback, and communicate with the ActionScript environment.
- */
-declare class FlashPlayer {
-	/**
-	 * True if this element is active.
-	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
-	 */
-	active: boolean;
-
-	/**
-	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
-
-	/**
-	 * The boundaries of the element, in parent-relative coordinates.
-	 * Setting an element's size or location changes its bounds property, and vice-versa.
-	 */
-	bounds: Bounds;
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The help text that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The number of pixels to indent the element during automatic layout.
-	 * Applies for column orientation and left alignment, or row orientation and top alignment.
-	 */
-	indent: number;
-
-	/**
-	 * The upper left corner of this element relative to its parent.
-	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
-	 */
-	location: Point;
-
-	/**
-	 * The maximum height and width to which the element can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * The minimum height and width to which the element can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size, used by layout managers to determine the best size for each element.
-	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
-	 * A FlashPlayer object has no creation properties.
-	 */
-	properties: Object;
-
-	/**
-	 * The current dimensions of this element.
-	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
-	 */
-	size: Dimension;
-
-	/**
-	 * The element type, "flashplayer".
-	 */
-	readonly type: string;
-
-	/**
-	 * True if this element is shown, false if it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this element relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this element.
-	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * A function definition for a callback from the Flash ActionScript environment.
-	 * The Flash ActionScript code can call any callback function defined on the ExtendScript side of the FlashPlayer object, invoking it by name as a property of the control object. The function can take any arguments of a supported data types, and can return any value of a supported data type. data types:Number, String, Boolean, null, undefined, Object, Array.
-	 */
-	callback(): void;
-
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): Event;
-
-	/**
-	 * Hides this element.
-	 */
-	hide(): void;
-
-	/**
-	 * Invokes an ActionScript function defined in the Flash application.
-	 * Returns the result of the invoked function, which must be one of the allowed types. The ActionScript class and date objects are not supported as return values.
-	 * @param name The name of a Flash ActionScript function that has been registered with the ExternalInterface object by the currently loaded SWF file.
-	 * @param argument An argument to pass through to the function. There can be any number of arguments. An argument must be one of these data types:Number, String, Boolean, null, undefined, Object, Array. No other data types are supported.
-	 */
-	invokePlayerFunction(name: string, argument?: any): any;
-
-	/**
-	 * Loads a movie into the Flash Player, and begins playing it.
-	 * @param file The File object for the SWF file to load.
-	 */
-	loadMovie(file: File): void;
-
-	/**
-	 * Sends a notification message, simulating the specified user interaction event.
-	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
-	 */
-	notify(eventName?: string): void;
-
-	/**
-	 * Restarts a movie that has been stopped.
-	 * Do not use on a movie that is currently playing.The stopMovie()-playMovie() sequence does not work for SWF files produced by Flex, or for some files produced by Flash Authoring (depending on how they were implemented).
-	 * @param rewind When true, restarts the movie from the beginning; otherwise, starts playing from the	point where it was stopped.
-	 */
-	playMovie(rewind: boolean): void;
-
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this element.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Shows this element.
-	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
-	 */
-	show(): void;
-
-	/**
-	 * Halts playback of the current movie.
-	 * The stopMovie()-playMovie() sequence does not work for SWF files produced by Flex, or for some files produced by Flash Authoring (depending on how they were implemented).Using stopMovie() from the player's hosting environment has no effect on an SWF file playing in a ScriptUI Flash Player element. It is, however, possible to produce an SWF using Flash Authoring that can stop itself in response to user interaction.
-	 */
-	stopMovie(): void;
-
-}
-
-/**
- * A container for other controls within a window.
- * A group can specify layout options for its child elements. Hiding a group hides all its children. Making it visible makes visible those children that are not individually hidden.
- */
-declare class Group {
-	/**
-	 * Tells the layout manager how unlike-sized children of this container should be aligned within a column or row.
-	 * Order of creation determines which children are at the top of a column or the left of a row; the earlier a child is created, the closer it is to the top or left of its column or row. If defined, alignment for a child element overrides the alignChildren setting for the parent container. See alignment property for values.
-	 */
-	alignChildren: string;
-
-	/**
-	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
-
-	/**
-	 * The boundaries of the element, in parent-relative coordinates.
-	 * Setting an element's size or location changes its bounds property, and vice-versa.
-	 */
-	bounds: Bounds;
-
-	/**
-	 * An array of child elements.
-	 */
-	readonly children: Object[];
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
-	 */
-	readonly graphics: ScriptUIGraphics;
-
-	/**
-	 * The help text that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The number of pixels to indent the element during automatic layout.
-	 * Applies for column orientation and left alignment, or row orientation and top alignment.
-	 */
-	indent: number;
-
-	/**
-	 * The layout manager for this container.
-	 * The first time a container object is made visible, ScriptUI invokes this layout manager by calling its layout() function. Default is an instance of the LayoutManager class that is automatically created when the container element is created.
-	 */
-	layout: LayoutManager;
-
-	/**
-	 * The upper left corner of this element relative to its parent.
-	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
-	 */
-	location: Point;
-
-	/**
-	 * The number of pixels between the edges of a container and the outermost child elements.
-	 * You can specify different margins for each edge of the container. The default value is based on the type of container, and is chosen to match the standard Adobe UI guidelines.
-	 */
-	margins: number;
-
-	/**
-	 * The maximum height and width to which the element can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * The minimum height and width to which the element can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The layout orientation of children in a container.
-	 * Interpreted by the layout manager for the container. The default LayoutManager  Object accepts the (case-insensitive) values row, column, or stack.For window and panel, the default is column, and for group the default is row. The allowed values for the container’s alignChildren and its children’s alignment properties depend on the orientation.
-	 */
-	orientation: string;
-
-	/**
-	 * The parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size, used by layout managers to determine the best size for each element.
-	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the control (properties used only when the element is created).
-	 * A Group object has no creation properties.
-	 */
-	properties: Object;
-
-	/**
-	 * The current dimensions of this element.
-	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
-	 */
-	size: Dimension;
-
-	/**
-	 * The number of pixels separating one child element from its adjacent sibling element.
-	 * Because each container holds only a single row or column of children, only a single spacing value is needed for a container. The default value is based on the type of container, and is chosen to match standard Adobe UI guidelines.
-	 */
-	spacing: number;
-
-	/**
-	 * The element type; "group".
-	 */
-	readonly type: string;
-
-	/**
-	 * True if this element is shown, false if it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this element relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Adds a child element to this container.
-	 * Creates and returns a new control or container object and adds it to the children of this group.
-	 * @param type The type of the child element, as specified for the type property. Control types are listed in the JavaScript Tools Guide.
-	 * @param bounds A bounds specification that describes the size and position of the new control or container, relative to its parent. If supplied, this value creates a new Bounds object which is assigned to the new object’s bounds property.
-	 * @param text The text or label, a localizable string. Initial text to be displayed in the control as the title, label, or contents, depending on the control type. If supplied, this value is assigned to the new object’s text property.
-	 * @param properties An object that contains one or more creation properties of the new child (properties used only when the element is created). The creation properties depend on the element type. See properties property of each control type.
-	 */
-	add(type: string, bounds?: Bounds, text?: string, properties?: Object): Object;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this element.
-	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): Event;
-
-	/**
-	 * Hides this element.
-	 */
-	hide(): void;
-
-	/**
-	 * An event-handler callback function, called when the group is about to be drawn.
-	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
-	 */
-	onDraw(): void;
-
-	/**
-	 * Removes the specified child control from this group's children array.
-	 * No error results if the child does not exist.
-	 * @param what The child control to remove, specified by 0-based index, text property value, or as a control object.
-	 */
-	remove(what: any): void;
-
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this element.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Shows this element.
-	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
-	 */
-	show(): void;
-
-}
-
-/**
- * A container for other types of controls, with an optional frame.
- * A panel can specify layout options for its child elements. Hiding a panel hides all its children. Making it visible makes visible those children that are not individually hidden.
- */
-declare class Panel {
-	/**
-	 * Specifies how to align the child elements.
-	 */
-	alignChildren: string;
-
-	/**
-	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
-	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
-	 * For orientation=row:top, bottom, fill
-	 * For orientation=column: left, right, fill
-	 * For orientation=stack:top, bottom, left, right, fill
-	 */
-	alignment: string;
-
-	/**
-	 * The boundaries of the element, in parent-relative coordinates.
-	 * Setting an element's size or location changes its bounds property, and vice-versa.
-	 */
-	bounds: Bounds;
-
-	/**
-	 * Reserve space for the specified number of characters; affects calculation of preferredSize .
-	 */
-	characters: number;
-
-	/**
-	 * An array of child elements.
-	 */
-	readonly children: Object[];
-
-	/**
-	 * True if this element is enabled.
-	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
-	 */
-	enabled: boolean;
-
-	/**
-	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
-	 */
-	readonly graphics: ScriptUIGraphics;
-
-	/**
-	 * The help text that is displayed when the mouse hovers over the element.
-	 */
-	helpTip: string;
-
-	/**
-	 * The number of pixels to indent the element during automatic layout.
-	 * Applies for column orientation and left alignment, or row orientation and top alignment.
-	 */
-	indent: number;
-
-	/**
-	 * The default text justification style for child text elements.
-	 * One of left, center, or right. Justification only works if this value is set on creation of the element.
-	 */
-	justify: string;
-
-	/**
-	 * The layout manager for this container.
-	 * The first time a container object is made visible, ScriptUI invokes this layout manager by calling its layout() function. Default is an instance of the LayoutManager class that is automatically created when the container element is created.
-	 */
-	layout: LayoutManager;
-
-	/**
-	 * The upper left corner of this element's frame relative to its parent.
-	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
-	 */
-	location: Point;
-
-	/**
-	 * The number of pixels between the edges of a container and the outermost child elements.
-	 * You can specify different margins for each edge of the container. The default value is based on the type of container, and is chosen to match the standard Adobe UI guidelines.
-	 */
-	margins: number;
-
-	/**
-	 * The maximum height and width to which the element can be resized.
-	 */
-	maximumSize: Dimension;
-
-	/**
-	 * The minimum height and width to which the element can be resized.
-	 */
-	minimumSize: Dimension;
-
-	/**
-	 * The layout orientation of children in a container.
-	 * Interpreted by the layout manager for the container. The default LayoutManager  Object accepts the (case-insensitive) values row, column, or stack.For window and panel, the default is column, and for group the default is row. The allowed values for the container’s alignChildren and its children’s alignment properties depend on the orientation.
-	 */
-	orientation: string;
-
-	/**
-	 * The parent element.
-	 */
-	readonly parent: Object;
-
-	/**
-	 * The preferred size, used by layout managers to determine the best size for each element.
-	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
-	 */
-	preferredSize: Dimension;
-
-	/**
-	 * An object that contains one or more creation properties of the control (properties used only when the element is created).
-	 * Creation properties of a Panel object can include:
-	 * borderStyle: A string that specifies the appearance of the border drawn around the panel. One of black, etched, gray, raised, sunken. Default is etched.
-	 * su1PanelCoordinates: Photoshop only. When true, this panel automatically adjusts the positions of its children for compatability with Photoshop CS. Default is false, meaning that the panel does not adjust the positions of its children, even if the parent window has automatic adjustment enabled.
-	 */
-	properties: Object;
-
-	/**
-	 * The current dimensions of this element.
-	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
-	 */
-	size: Dimension;
-
-	/**
-	 * The number of pixels separating one child element from its adjacent sibling element.
-	 * Because each container holds only a single row or column of children, only a single spacing value is needed for a container. The default value is based on the type of container, and is chosen to match standard Adobe UI guidelines.
-	 */
-	spacing: number;
-
-	/**
-	 * The title or label text, a localizable string.
-	 */
-	text: string;
-
-	/**
-	 * The element type; "panel".
-	 */
-	readonly type: string;
-
-	/**
-	 * True if this element is shown, false if it is hidden.
-	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
-	 */
-	visible: boolean;
-
-	/**
-	 * The window that this element belongs to.
-	 */
-	readonly window: Window;
-
-	/**
-	 * The bounds of this element relative to the top-level parent window.
-	 */
-	readonly windowBounds: Bounds;
-
-	/**
-	 * Adds a child element to this container.
-	 * Creates and returns a new control or container object and adds it to the children of this group.
-	 * @param type The type of the child element, as specified for the type property. Control types are listed in the JavaScript Tools Guide.
-	 * @param bounds A bounds specification that describes the size and position of the new control or container, relative to its parent. If supplied, this value creates a new Bounds object which is assigned to the new object’s bounds property.
-	 * @param text The text or label, a localizable string. Initial text to be displayed in the control as the title, label, or contents, depending on the control type. If supplied, this value is assigned to the new object’s text property.
-	 * @param properties An object that contains one or more creation properties of the new child (properties used only when the element is created). The creation properties depend on the element type. See properties property of each control type.
-	 */
-	add(type: string, bounds?: Bounds, text?: string, properties?: Object): Object;
-
-	/**
-	 * Registers an event handler for a particular type of event occuring in this element.
-	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
-	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
-	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
-	 */
-	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Simulates the occurrence of an event in this target.
-	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
-	 */
-	dispatchEvent(): Event;
-
-	/**
-	 * Hides this element.
-	 */
-	hide(): void;
-
-	/**
-	 * An event-handler callback function, called when the panel is about to be drawn.
-	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
-	 */
-	onDraw(): void;
-
-	/**
-	 * Removes the specified child control from this group's children array.
-	 * No error results if the child does not exist.
-	 * @param what The child control to remove, specified by 0-based index, text property value, or as a control object.
-	 */
-	remove(what: any): void;
-
-	/**
-	 * Unregisters an event handler for a particular type of event occuring in this element.
-	 * All arguments must be identical to those that were used to register the event handler.
-	 * @param eventName The name of the event.
-	 * @param handler The function that handles the event.
-	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
-	 */
-	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
-
-	/**
-	 * Shows this element.
-	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
-	 */
-	show(): void;
-
-}
-
-/**
  * Defines the location of a window or UI element. Contains a 2-element array.
  * Specifies the origin point of an element as horizontal and vertical pixel offsets from the origin of the element's coordinate space.
  * A Point object is created when you set an element’s location property. You can set the property using a JavaScript object with properties named x and y, or an array with 2 values in the order [x, y].
@@ -4184,104 +841,6 @@ declare class Bounds {
 	 * The vertical coordinate, a pixel offset from the origin of the element's coordinate space.
 	 */
 	y: number;
-
-}
-
-/**
- * Encapsulates input event information for an event that propagates through a container and control hierarchy.
- * Implements W3C standard event handling. This object is passed to a function that you register to respond to events of a certain type that occur in a window or control. Use windowObj.addEventListener() or controlObj.addEventListener() to register a handler function.
- */
-declare class UIEvent {
-	/**
-	 * True if the event is of a type that bubbles.
-	 */
-	readonly bubbles: boolean;
-
-	/**
-	 * True if the default action associated with the event can be canceled with preventDefault().
-	 */
-	readonly cancelable: boolean;
-
-	/**
-	 * True if this event can be captured.
-	 */
-	readonly captures: boolean;
-
-	/**
-	 * The event target object which is currently handling the event. During capturing and bubbling, this is different from the property target.
-	 */
-	readonly currentTarget: boolean;
-
-	/**
-	 * The click count for a mouse-click event.
-	 */
-	readonly detail: any;
-
-	/**
-	 * The current phase of event propagation; one of none, target, capture, bubble.
-	 */
-	readonly eventPhase: string;
-
-	/**
-	 * The event target object for this event.
-	 */
-	readonly target: Object;
-
-	/**
-	 * The date and time at which the event occurred.
-	 */
-	readonly timeStamp: Date;
-
-	/**
-	 * The name of the event that thisobject represents.
-	 * Event types are listed in the JavaScript Tools Guide.
-	 */
-	readonly type: string;
-
-	/**
-	 * The ScriptUI element that this event relates to.
-	 */
-	readonly view: any;
-
-	/**
-	 * Creates an event.
-	 * The UIEvent object is normally created by ScriptUI and passed to your event handler. However, you can simulate a user action by constructing an event object and sending it to a target object’s dispatchEvent() function.
-	 * @param type The event type. See UIEvent.type property.
-	 * @param captures Set to true if this event can be captured.
-	 * @param bubbles Set to true if the event bubbles.
-	 * @param view The ScriptUI element that this event relates to.
-	 * @param detail The click count for a mouse-click event.
-	 */
-	constructor(type: string, captures: boolean, bubbles: boolean, view?: Object, detail?: number);
-
-	/**
-	 * Initializes a UI event as a core W3C event.
-	 * @param type The event type.
-	 * @param captures Set to true if this event can be captured.
-	 * @param bubbles Set to true if the event bubbles.
-	 * @param cancelable Set to true if the default action is cancelable.
-	 */
-	initEvent(type: string, captures: boolean, bubbles: boolean, cancelable: boolean): void;
-
-	/**
-	 * Initializes an event.
-	 * @param type The event type.
-	 * @param captures Set to true if this event can be captured.
-	 * @param bubbles Set to true if the event bubbles.
-	 * @param view The ScriptUI element that this event relates to.
-	 * @param detail The click count for a mouse-click event.
-	 */
-	initUIEvent(type: string, captures: boolean, bubbles: boolean, view?: Object, detail?: number): void;
-
-	/**
-	 * Prevents the default action associated with this event from being called.
-	 */
-	preventDefault(): void;
-
-	/**
-	 * Stops the propagation of this event.
-	 */
-	stopPropagation(): void;
 
 }
 

--- a/ScriptUI/retired.d.ts
+++ b/ScriptUI/retired.d.ts
@@ -1,0 +1,4016 @@
+
+/**
+ * A global class containing central information about ScriptUI. Not instantiable.
+ */
+declare class ScriptUI {
+	/**
+	 * Collects the enumerated values that can be used in the alignment and alignChildren properties of controls and containers.
+	 * Predefined alignment values are: TOP, BOTTOM, LEFT, RIGHT, FILL, CENTER
+	 */
+	static readonly Alignment: string;
+
+	/**
+	 * Collects the enumerated values that can be used as the style argument to the ScriptUI.newFont() method.
+	 * Predefined styles are REGULAR, BOLD, ITALIC, BOLDITALIC.
+	 */
+	static readonly FontStyle: Object;
+
+	/**
+	 * The font constants defined by the host application.
+	 */
+	static readonly applicationFonts: Object;
+
+	/**
+	 * An object whose properties are the names of compatability modes supported by the host application.
+	 * The presence of ScriptUI.compatability.su1PanelCoordinates means that the application allows backward compatibility with the coordinate system of Panel elements in ScriptUI version 1.
+	 */
+	static readonly compatibility: Object;
+
+	/**
+	 * A string containing the internal version number of the ScriptUI module.
+	 */
+	static readonly coreVersion: string;
+
+	/**
+	 * An object whose properties define attributes of the environment in which ScriptUI operates.
+	 */
+	static readonly environment: Environment;
+
+	/**
+	 * An object whose properties and methods provide access to objects used in the ScriptUI event system.
+	 * It contains one function, createEvent(), which allows you to create event objects in order to simulate user-interaction event
+	 */
+	static readonly events: Events;
+
+	/**
+	 * A string containing the name of the UI component framework with which this version of ScriptUI is compatible.
+	 */
+	static readonly frameworkName: string;
+
+	/**
+	 * A string containing the version number of the ScriptUI component framework
+	 */
+	static readonly version: any;
+
+	/**
+	 * Finds and returns the resource for a given text string from the host application's resource data.
+	 * If no string resource matches the given text, the text itself is returned.
+	 * @param text The text to match.
+	 */
+	static getResourceText(text: string): string;
+
+	/**
+	 * Creates a new font object for use in text controls and titles.
+	 * @param name The font name, or the font family name.
+	 * @param style The font style; can be string, or one of the values of ScriptUI.FontStyle.
+	 * @param size The font size in points.
+	 */
+	static newFont(name: string, style: string, size: number): ScriptUIFont;
+
+	/**
+	 * Loads a new image from resources or disk files into an image object.
+	 * Creates a new global image object for use in controls that can display images, loading the associated images from the specified resources or image files.
+	 * @param normal The resource name or the disk file path to the image used for the normal state.
+	 * @param disabled The resource name, or the disk file path to the image used for the disabled state.
+	 * @param pressed The resource name, or the file-system path to the image used for the pressed state.
+	 * @param rollover The resource name, or the file-system path to the image used for the rollover state.
+	 */
+	static newImage(normal: string, disabled?: string, pressed?: string, rollover?: string): ScriptUIImage;
+
+}
+
+/**
+ * The instance represents a top-level window or dialog box, which contains user-interface elements.
+ * The globally available Window object provides access to predefined and script-defined windows.
+ */
+declare class Window {
+	/**
+	 * Set to true to make this window active.
+	 * A modal dialog that is visible is by definition the active dialog.
+	 * An active palette is the front-most window.
+	 * An active control is the one with focus—that is, the one that accepts keystrokes, or in the case of a Button, be selected when the user typesReturn or Enter.
+	 */
+	active: boolean;
+
+	/**
+	 * Tells the layout manager how unlike-sized children of this container should be aligned within a column or row.
+	 * Order of creation determines which children are at the top of a column or the left of a row; the earlier a child is created, the closer it is to the top or left of its column or row. If defined, alignment for a child element overrides the alignChildren setting for the parent container. See alignment property for values.
+	 */
+	alignChildren: string;
+
+	/**
+	 * The alignment style for child elements of a container. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The bounds of the window's drawable area, excluding the frame, in screen coordinates.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * For windows of type dialog, the UI element to notify when the user presses a cancellation key combination.
+	 * The cancellation key is the Esc key. By default, looks for a button whose name or text is "cancel" (case disregarded).
+	 */
+	cancelElement: Object;
+
+	/**
+	 * A number of characters for which to reserve space when calculating the preferred size of the window.
+	 */
+	characters: number;
+
+	/**
+	 * The collection of UI elements that have been added to this container.
+	 * An array indexed by number or by a string containing an element's name. The length property of this array is the number of child elements for container elements, and is zero for controls.
+	 */
+	readonly children: Object[];
+
+	/**
+	 * For windows of type dialog, the UI element to notify when the user presses a Enter key.
+	 * By default, looks for a button whose name or text is "ok" (case disregarded).
+	 */
+	defaultElement: Object;
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The bounds of the window frame in screen coordinates.
+	 * The frame consists of the title bar and borders that enclose the content region of a window, depending on the windowing system.
+	 */
+	readonly frameBounds: Bounds;
+
+	/**
+	 * The top left corner of the window frame in screen coordinates.
+	 * The same as [frameBounds.x, frameBounds.y]. Set this value to move the window frame to the specified location on the screen. The frameBounds value changes accordingly.
+	 */
+	frameLocation: Point;
+
+	/**
+	 * The size and location of the window's frame in screen coordinates.
+	 */
+	readonly frameSize: Dimension;
+
+	/**
+	 * Deprecated. Use ScriptUI.frameworkName instead.
+	 */
+	static readonly frameworkName: string;
+
+	/**
+	 * The graphics object that can be used to customize the window’s appearance, in response to the onDraw event.
+	 */
+	readonly graphics: ScriptUIGraphics;
+
+	/**
+	 * The help text that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The number of pixels to indent the element.
+	 */
+	indent: number;
+
+	/**
+	 * The default text justification style for child text elements.
+	 * One of left, center, or right. Justification only works if this value is set on creation of the element.
+	 */
+	justify: string;
+
+	/**
+	 * The layout manager for this container.
+	 * The first time a container object is made visible, ScriptUI invokes this layout manager by calling its layout() function. Default is an instance of the LayoutManager class that is automatically created when the container element is created.
+	 */
+	layout: LayoutManager;
+
+	/**
+	 * The upper left corner of the window's drawable area.
+	 * The same as [bounds.x, bounds.y].
+	 */
+	location: Point;
+
+	/**
+	 * The number of pixels between the edges of a container and the outermost child elements.
+	 * You can specify different margins for each edge of the container. The default value is based on the type of container, and is chosen to match the standard Adobe UI guidelines.
+	 */
+	margins: number;
+
+	/**
+	 * True if the window is expanded.
+	 */
+	maximized: boolean;
+
+	/**
+	 * The largest rectangle to which the window can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * True if the window is minimized or iconified.
+	 */
+	minimized: boolean;
+
+	/**
+	 * The smallest rectangle to which the window can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The opacity of the window, in the range [0..1].
+	 * A value of 1.0 (the default) makes the window completely opaque, a value of 0 makes it completely transparent. Intermediate values make it partially transparent to any degree.
+	 */
+	opacity: number;
+
+	/**
+	 * The layout orientation of children in a container.
+	 * Interpreted by the layout manager for the container. The default LayoutManager  Object accepts the (case-insensitive) values row, column, or stack.For window and panel, the default is column, and for group the default is row. The allowed values for the container’s alignChildren and its children’s alignment properties depend on the orientation.
+	 */
+	orientation: string;
+
+	/**
+	 * The immediate parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size of the window.
+	 * Used in automatic layout and resizing. To set a specific value for only one dimension, specify the other dimension as -1.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
+	 * Creation properties of a Window object can include:
+	 * resizeable: When true, the window can be resized by the user. Default is false.
+	 * su1PanelCoordinates: Photoshop only. When true, the child panels of this window automatically adjust the positions of their children for compatability with Photoshop CS (in which the vertical coordinate was measured from outside the frame). Default is false. Individual panels can override the parent window’s setting.
+	 * closeButton: Bridge only. When true, the title bar includes a button to close the window, if the platform and window type allow it. When false, it does not. Default is true. Not used for dialogs.
+	 * maximizeButton: Bridge only. When true, the title bar includes a button to expand the window to its maximum size (typically, the entire screen), if the platform and window type allow it. When false, it does not. Default is false for type palette, true for type window. Not used for dialogs.
+	 */
+	properties: Object;
+
+	/**
+	 * The keypress combination that invokes this element's onShortcutKey() callback.
+	 */
+	shortcutKey: string;
+
+	/**
+	 * The current size and location of the content area of the window in screen coordinates.
+	 */
+	size: Dimension;
+
+	/**
+	 * The number of pixels separating one child element from its adjacent sibling element.
+	 * Because each container holds only a single row or column of children, only a single spacing value is needed for a container. The default value is based on the type of container, and is chosen to match standard Adobe UI guidelines.
+	 */
+	spacing: number;
+
+	/**
+	 * The title, label, or displayed text, a localizeable string.
+	 * Does not apply to containers of type group.
+	 */
+	text: string;
+
+	/**
+	 * The element type; "dialog", "palette", or "window".
+	 */
+	readonly type: string;
+
+	/**
+	 * Deprecated. Use ScriptUI.version instead.
+	 */
+	static readonly version: any;
+
+	/**
+	 * When true, the element is shown, when false it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this window relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Creates a new window.
+	 * @param type The window type. One of: window: Creates a simple window that can be used as a main window for an application. (Not supported by Photoshop CS3.) palette: Creates a modeless dialog, also called a floating palette. (Not supported by Photoshop CS3.) dialog: Creates a modal dialog. This argument can also be a ScriptUI resource specification; in that case, all other arguments are ignored.
+	 * @param title The window title, a localizable string.
+	 * @param bounds The window's position and size.
+	 * @param properties An object containing creation-only properties. Can contain any of these properties: resizeable: When true, the window can be resized by the user. Default is false. su1PanelCoordinates: Photoshop only. When true, the child panels of this window automatically adjust the positions of their children for compatability with Photoshop CS (in which the vertical coordinate was measured from outside the frame). Default is false. Individual panels can override the parent window’s setting. closeButton:When true, the title bar includes a button to close the window, if the platform and window type allow it. When false, it does not. Default is true. Not used for dialogs. maximizeButton:When true, the title bar includes a button to expand the window to its maximum size (typically, the entire screen), if the platform and window type allow it. When false, it does not. Default is false for type palette, true for type window. Not used for dialogs. minimizeButton: When true, the title bar includes a button to minimize or iconify the window, if the platform and window type allow it. When false, it does not. Default is false for type palette, true for type window. Main windows cannot have a minimize button in Mac OS. Not used for dialogs. independent:When true, a window of type window is independent of other application windows, and can be hidden behind them in Windows. In Mac OS, has no effect. Default is false. borderless:When true, the window has no title bar or borders. Properties that control those features are ignored.
+	 */
+	constructor(type: string, title?: string, bounds?: Bounds, properties?: Object);
+
+	/**
+	 * Creates and returns a new control or container object and adds it to the children of this window.
+	 * @param type The type of the child element, as specified for the type property. Control types are listed in the JavaScript Tools Guide.
+	 * @param bounds A bounds specification that describes the size and position of the new control or container, relative to its parent. If supplied, this value creates a new Bounds object which is assigned to the new object’s bounds property.
+	 * @param text The text or label, a localizable string. Initial text to be displayed in the control as the title, label, or contents, depending on the control type. If supplied, this value is assigned to the new object’s text property.
+	 * @param properties An object that contains one or more creation properties of the new child (properties used only when the element is created). The creation properties depend on the element type. See properties property of each control type.
+	 */
+	add(type: 'button', bounds?: Bounds, text?: string, creation_properties?: {name?: string;}): Button;
+	add(type: 'checkbox', bounds?: Bounds, text?: string, creation_properties?: {name?: string;}): Checkbox;
+	add(type: 'dropdownlist', bounds?: Bounds, items?: string[], creation_properties?: {name?: string; items?: string[];}): DropDownList;
+	add(type: 'edittext', bounds?: Bounds, text?: string, creation_properties?: {name?: string; readonly?: boolean; noecho?: boolean; enterKeySignalsOnChange?: boolean; borderless?: boolean; multiline?: boolean; scrollable?: boolean;}): EditText;
+	add(type: 'flashplayer', bounds?: Bounds, movieToLoad?: string | File, creation_properties?: {name?: string;}): FlashPlayer;
+	add(type: 'group', bounds?: Bounds, creation_properties?: {name?: string;}): Group;
+	add(type: 'iconbutton', bounds?: Bounds, icon?: string | File, creation_properties?: {name?: string; style?: string; toggle?: boolean;}): IconButton;
+	add(type: 'image', bounds?: Bounds, icon?: string | File, creation_properties?: {name?: string;}): Image;
+	add(type: 'listbox', bounds?: Bounds, items?: string[], creation_properties?: {name?: string; multiselect?: boolean; items?: string[]; numberOfColumns?: number; showHeaders?: boolean; columnWidths?: number[]; columnTitles?: string[];}): ListBox;
+	add(type: 'panel', bounds?: Bounds, text?: string, creation_properties?: {name?: string; borderStyle?: string; su1PanelCoordinates?: boolean;}): Panel;
+	add(type: 'progressbar', bounds?: Bounds, value?: number, minvalue?: number, maxvalue?: number, creation_properties?: {name?: string;}): ProgressBar;
+	add(type: 'radiobutton', bounds?: Bounds, text?: string, creation_properties?: {name?: string;}): RadioButton;
+	add(type: 'scrollbar', bounds?: Bounds, value?: number, minvalue?: number, maxvalue?: number, creation_properties?: {name?: string;}): Scrollbar;
+	add(type: 'slider', bounds?: Bounds, value?: number, minvalue?: number, maxvalue?: number, creation_properties?: {name?: string;}): Slider;
+	add(type: 'statictext', bounds?: Bounds, text?: string, creation_properties?: {name?: string; multiline?: boolean; scrolling?: boolean; truncate?: string;}): StaticText;
+	add(type: 'tab', bounds?: Bounds, text?: string, creation_properties?: {name?: string;}): Tab;
+	add(type: 'tabbedpanel', bounds?: Bounds, text?: string, creation_properties?: {name?: string;}): TabbedPanel;
+	add(type: 'treeview', bounds?: Bounds, items?: string[], creation_properties?: {name?: string; itmes?: string[];}): TreeView;
+	add(type: string, bounds?: Bounds, text?: string, properties?: Object): Object;
+	
+	/**
+	 * Registers an event handler for a particular type of event occuring in this window.
+	 * @param eventName The name of the event. Predefined event names are: change, changing, move, moving, resize, resizing, show , enterKey, focus, blur, keydown, keyup, mousedown, mouseup, mousemove, mouseover, mouseout, click (detail = 1 for single, 2 for double).
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase?: boolean): boolean;
+
+	/**
+	 * Displays a platform-standard dialog containing a short message and an OK button.
+	 * @param message TThe string for the displayed message.
+	 * @param title A string to appear as the title of the dialog, if the platform supports a title. Ignored in Mac OS, which does not support titles for alert dialogs. The default title string is "Script Alert".
+	 * @param errorIcon When true, the platform-standard alert icon is replaced by the platform-standard error icon in the dialog. Ignored in Mac OS, which does not support icons for alert dialogs.
+	 */
+	static alert(message: string, title?: string, errorIcon?: boolean): void;
+
+	/**
+	 * Centers this window on screen or with repect to another window.
+	 * @param window The relative window. If not specified, centers on the screen.
+	 */
+	center(window?: Window): void;
+
+	/**
+	 * Closes this window.
+	 * . If an onClose() callback is defined for the window, calls that function before closing the window.
+	 * @param return A number to be returned from the show() method that invoked this window as a modal dialog.
+	 */
+	close(return_?: any): void;
+
+	/**
+	 * Displays a platform-standard dialog containing a short message and two buttons labeled Yes and No.
+	 * Returns true if the user clicked Yes, false if the user clicked No.
+	 * @param message The string for the displayed message.
+	 * @param noAsDefault When true, the No button is the default choice, selected when the user types Enter. Default is false, meaning that Yes is the default choice.
+	 * @param title A string to appear as the title of the dialog, if the platform supports a title. Ignored in Mac OS, which does not support titles for alert dialogs. The default title string is "Script Alert".
+	 */
+	static confirm(message: string, noAsDefault: boolean, title?: string): boolean;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): UIEvent;
+
+	/**
+	 * Use this method to find an existing window.
+	 * This includes windows defined by ScriptUI resource strings, windows already created by a script, and windows created by the application (if the application supports this case). This function is not supported by all applications. Returns a Window object found or generated from the resource, or null if no such window or resource exists.
+	 * @param type The name of a predefined resource available to JavaScript in the current application; or the window type. If a title is specified, the type is used if more than one window with that title is found. Can be null or the empty string.
+	 * @param title The window title.
+	 */
+	static find(type: string, title: string): Window;
+
+	/**
+	 * Hides this windows.
+	 * When a window is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states. For a modal dialog, closes the dialog and sets its result to 0.
+	 */
+	hide(): void;
+
+	/**
+	 * Sends a notification message to all listeners, simulating the specified user interaction event.
+	 * @param eventName The event name; if omitted, the default event is sent. One of: onClose, onMove, onMoving, onResize, onResizing, onShow
+	 */
+	notify(eventName?: string): void;
+
+	/**
+	 * An event-handler callback function, called when the window acquires the keyboard focus.
+	 * Called when the user gives the window the keyboard focus by clicking it or otherwise making it the active window.
+	 */
+	onActivate(): void;
+
+	/**
+	 * An event-handler callback function, calledwhen the window is about to be closed.
+	 * Called when a request is made to close the window, either by an explicit call to the close() function or by a user action (clicking the OS-specific close icon in the title bar). The function is called before the window actually closes; it can return false to cancel the close operation.
+	 */
+	onClose(): boolean;
+
+	/**
+	 * An event-handler callback function, called when the window loses the keyboard focus.
+	 * Called when the user moves the keyboard focus from the previously active window to another window.
+	 */
+	onDeactivate(): void;
+
+	/**
+	 * An event-handler callback function, calledwhen the windowhas been moved
+	 */
+	onMove(): void;
+
+	/**
+	 * An event-handler callback function, calledwhen the window is being moved
+	 * Called while a window in being moved, each time the position changes. A handler can monitor the move operation.
+	 */
+	onMoving(): void;
+
+	/**
+	 * An event-handler callback function, called after the window has been resized
+	 */
+	onResize(): void;
+
+	/**
+	 * An event-handler callback function, called while a window is being resized
+	 * Called while a window is being resized, each time the height or width changes. A handler can monitor the resize operation.
+	 */
+	onResizing(): void;
+
+	/**
+	 * In Windows only, an event-handler callback function, called a shortcut-key sequence is typed that matches the shortcutKey value for this window.
+	 */
+	onShortcutKey(): void;
+
+	/**
+	 * An event-handler callback function, called just before the window is displayed
+	 * Called when a request is made to open the window using the show() method, before the window is made visible, but after automatic layout is complete. A handler can modify the results of the automatic layout.
+	 */
+	onShow(): void;
+
+	/**
+	 * Displays a modal dialog that returns the user’s text input.
+	 * Returns the value of the text edit field if the user clicked OK, null if the user clicked Cancel.
+	 * @param prompt The string for the displayed message.
+	 * @param default The initial value to be displayed in the text edit field.
+	 * @param title A string to appear as the title of the dialog. In Windows, this appears in the window’s frame; in Mac OS it appears above the message. The default title string is "Script Prompt".
+	 */
+	static prompt(prompt: string, default_?: string, title?: string): string;
+
+	/**
+	 * Removes the specified child control from this window’s children array.
+	 * No error results if the child does not exist.
+	 * @param what The child control to remove, specified by 0-based index, text property value, or as a control object.
+	 */
+	remove(what: any): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this window.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Makes this window visible.
+	 * If an onShow() callback is defined for a window, calls that function before showing the window.When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states. For a modal dialog, opens the dialog and does not return until the dialog is dismissed. If it is dismissed via the close() method, this method returns any result value passed to that method. Otherwise, returns 0.
+	 */
+	show(): number | any;
+
+}
+
+/**
+ * A hierarchical list whose items can contain child items.
+ * The ListItem children of this control (in the items array) can be of type node, which means that they can contain child items. An item with child items can expanded, so that the child items are displayed, or collapsed, so that the child items are hidden Individual items can be selected at any level of the tree.
+ */
+declare class TreeView {
+	/**
+	 * True if this element is active.
+	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
+	 */
+	active: boolean;
+
+	/**
+	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The boundaries of the element, in parent-relative coordinates.
+	 * Setting an element's size or location changes its bounds property, and vice-versa.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * An array of child elements.
+	 */
+	readonly children: Object[];
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
+	 */
+	readonly graphics: ScriptUIGraphics;
+
+	/**
+	 * The help text that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The number of pixels to indent the element during automatic layout.
+	 * Applies for column orientation and left alignment, or row orientation and top alignment.
+	 */
+	indent: number;
+
+	/**
+	 * The width and height in pixels of each item in the list.
+	 * Used by auto-layout to determine the preferredSize of the list, if not otherwise specified. If not set explicitly, the size of each item is set to match the largest height and width among all items in the list
+	 */
+	itemSize: Dimension;
+
+	/**
+	 * The array of top-level items displayed in the list.
+	 * Access this array with a 0-based index. To obtain the number of items in the list, use items.length.The objects are created when items are specified on creation of the parent list object, or afterward using the list control’s add() method.
+	 */
+	readonly items: ListItem[];
+
+	/**
+	 * The upper left corner of this element relative to its parent.
+	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
+	 */
+	location: Point;
+
+	/**
+	 * The maximum height and width to which the element can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * The minimum height and width to which the element can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size, used by layout managers to determine the best size for each element.
+	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the control (properties used only when the element is created).
+	 * Creation properties of a ListBox object can include:
+	 * items: An array of strings for the text of each top-level list item. An item object is created for each item. An item with the text string "-" creates a separator item. Supply this property, or the items argument to the add() method, not both. This form is most useful for elements defined using Resource Specifications.
+	 */
+	properties: Object;
+
+	/**
+	 * The currently selectedlist item.
+	 * Setting this value causes the selected item to be highlighted and to be scrolled into view if necessary. If no items are selected, the value is null. Set to null to deselect all items.You can set the value using the index of an item, rather than an object reference. If set to an index value that is out of range, the operation is ignored. When set with an index value, the property still returns an object reference.
+	 */
+	selection: ListItem;
+
+	/**
+	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
+	 */
+	shortcutKey: string;
+
+	/**
+	 * The current dimensions of this element.
+	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
+	 */
+	size: Dimension;
+
+	/**
+	 * The element type, "treeview".
+	 */
+	readonly type: string;
+
+	/**
+	 * True if this element is shown, false if it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this element relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Adds an item to the top-level choices in this list.
+	 * Returns the item control object.
+	 * @param type The type of the child element, the string "item".
+	 * @param text The localizable text label for the item.
+	 */
+	add(type: string, text?: string): ListItem;
+
+	/**
+	 * Registers an event handler for a particular type of event occuring in this element.
+	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): Event;
+
+	/**
+	 * Retrieves an item object from the list that has a given text label.
+	 * @param text The text string to match.
+	 */
+	find(text: string): ListItem;
+
+	/**
+	 * Hides this element.
+	 */
+	hide(): void;
+
+	/**
+	 * Sends a notification message, simulating the specified user interaction event.
+	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
+	 */
+	notify(eventName?: string): void;
+
+	/**
+	 * An event-handler callback function, called when the element acquires the keyboard focus.
+	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
+	 */
+	onActivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the content of the element has been changed
+	 */
+	onChange(): void;
+
+	/**
+	 * An event-handler callback function, called when the user collapses (closes) an expanded node in the treeview.
+	 * @param item The ListItem node that collapsed.
+	 */
+	onCollapse(item: ListItem): void;
+
+	/**
+	 * An event-handler callback function, called when the element loses the keyboard focus.
+	 * Called when the user moves the keyboard focus from the previously active control to another control.
+	 */
+	onDeactivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the window is about to be drawn.
+	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
+	 */
+	onDraw(): void;
+
+	/**
+	 * An event-handler callback function, called when the user expands (opens) a collapsed node in the treeview.
+	 * @param item The ListItem node that expanded.
+	 */
+	onExpand(item: ListItem): void;
+
+	/**
+	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
+	 * In Windows only.
+	 */
+	onShortcutKey(): void;
+
+	/**
+	 * Removes a child item from the list.
+	 * @param what The item or child to remove, specified by 0-based index in the top-level item list, text value, or as a ListItem object.
+	 */
+	remove(what: any): void;
+
+	/**
+	 * Removes all child items from the list.
+	 */
+	removeAll(): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this element.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Shows this element.
+	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
+	 */
+	show(): void;
+
+}
+
+/**
+ * A control that contains a Flash Player, which can load and play Flash movies stored in SWF files.
+ * The ScriptUI FlashPlayer element runs the Flash application within an Adobe application. The Flash application runs ActionScript, a different implementation of JavaScript from the ExtendScript version of JavaScript that Adobe applications run. A control object of this type contains functions that allow your script to load SWF files, control movie playback, and communicate with the ActionScript environment.
+ */
+declare class FlashPlayer {
+	/**
+	 * True if this element is active.
+	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
+	 */
+	active: boolean;
+
+	/**
+	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The boundaries of the element, in parent-relative coordinates.
+	 * Setting an element's size or location changes its bounds property, and vice-versa.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The help text that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The number of pixels to indent the element during automatic layout.
+	 * Applies for column orientation and left alignment, or row orientation and top alignment.
+	 */
+	indent: number;
+
+	/**
+	 * The upper left corner of this element relative to its parent.
+	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
+	 */
+	location: Point;
+
+	/**
+	 * The maximum height and width to which the element can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * The minimum height and width to which the element can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size, used by layout managers to determine the best size for each element.
+	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
+	 * A FlashPlayer object has no creation properties.
+	 */
+	properties: Object;
+
+	/**
+	 * The current dimensions of this element.
+	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
+	 */
+	size: Dimension;
+
+	/**
+	 * The element type, "flashplayer".
+	 */
+	readonly type: string;
+
+	/**
+	 * True if this element is shown, false if it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this element relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Registers an event handler for a particular type of event occuring in this element.
+	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * A function definition for a callback from the Flash ActionScript environment.
+	 * The Flash ActionScript code can call any callback function defined on the ExtendScript side of the FlashPlayer object, invoking it by name as a property of the control object. The function can take any arguments of a supported data types, and can return any value of a supported data type. data types:Number, String, Boolean, null, undefined, Object, Array.
+	 */
+	callback(): void;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): Event;
+
+	/**
+	 * Hides this element.
+	 */
+	hide(): void;
+
+	/**
+	 * Invokes an ActionScript function defined in the Flash application.
+	 * Returns the result of the invoked function, which must be one of the allowed types. The ActionScript class and date objects are not supported as return values.
+	 * @param name The name of a Flash ActionScript function that has been registered with the ExternalInterface object by the currently loaded SWF file.
+	 * @param argument An argument to pass through to the function. There can be any number of arguments. An argument must be one of these data types:Number, String, Boolean, null, undefined, Object, Array. No other data types are supported.
+	 */
+	invokePlayerFunction(name: string, argument?: any): any;
+
+	/**
+	 * Loads a movie into the Flash Player, and begins playing it.
+	 * @param file The File object for the SWF file to load.
+	 */
+	loadMovie(file: File): void;
+
+	/**
+	 * Sends a notification message, simulating the specified user interaction event.
+	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
+	 */
+	notify(eventName?: string): void;
+
+	/**
+	 * Restarts a movie that has been stopped.
+	 * Do not use on a movie that is currently playing.The stopMovie()-playMovie() sequence does not work for SWF files produced by Flex, or for some files produced by Flash Authoring (depending on how they were implemented).
+	 * @param rewind When true, restarts the movie from the beginning; otherwise, starts playing from the	point where it was stopped.
+	 */
+	playMovie(rewind: boolean): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this element.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Shows this element.
+	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
+	 */
+	show(): void;
+
+	/**
+	 * Halts playback of the current movie.
+	 * The stopMovie()-playMovie() sequence does not work for SWF files produced by Flex, or for some files produced by Flash Authoring (depending on how they were implemented).Using stopMovie() from the player's hosting environment has no effect on an SWF file playing in a ScriptUI Flash Player element. It is, however, possible to produce an SWF using Flash Authoring that can stop itself in response to user interaction.
+	 */
+	stopMovie(): void;
+
+}
+
+
+/**
+ * A text label that the user cannot change.
+ */
+declare class StaticText {
+	/**
+	 * Always false. This element cannot have input focus.
+	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
+	 */
+	active: boolean;
+
+	/**
+	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The boundaries of the element, in parent-relative coordinates.
+	 * Setting an element's size or location changes its bounds property, and vice-versa.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * A number of characters for which to reserve space when calculating the preferred size of the element.
+	 */
+	characters: number;
+
+	/**
+	 * An array of child elements.
+	 */
+	readonly children: Object[];
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
+	 */
+	readonly graphics: ScriptUIGraphics;
+
+	/**
+	 * The help text that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The number of pixels to indent the element during automatic layout.
+	 * Applies for column orientation and left alignment, or row orientation and top alignment.
+	 */
+	indent: number;
+
+	/**
+	 * The text justification style.
+	 * One of left, center, or right. Justification only works if this value is set on creation of the element.
+	 */
+	justify: string;
+
+	/**
+	 * The upper left corner of this element relative to its parent.
+	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
+	 */
+	location: Point;
+
+	/**
+	 * The maximum height and width to which the element can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * The minimum height and width to which the element can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size, used by layout managers to determine the best size for each element.
+	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
+	 * Creation properties of a StaticText object can include:
+	 * multiline: When false (the default), the control displays a single line of text. When true, the control displays multiple lines, in which case the text wraps within the width of the control.
+	 * scrolling: When false (the default), the displayed text cannot be scrolled. When true, the displayed text can be vertically scrolled using the Up Arrow and Down Arrow; this case implies multiline=true.
+	 */
+	properties: Object;
+
+	/**
+	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
+	 */
+	shortcutKey: string;
+
+	/**
+	 * The current dimensions of this element.
+	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
+	 */
+	size: Dimension;
+
+	/**
+	 * The text to display, a localizable string.
+	 */
+	text: string;
+
+	/**
+	 * The element type, "statictext".
+	 */
+	readonly type: string;
+
+	/**
+	 * True if this element is shown, false if it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this element relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Registers an event handler for a particular type of event occuring in this element.
+	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): Event;
+
+	/**
+	 * Hides this element.
+	 */
+	hide(): void;
+
+	/**
+	 * Sends a notification message, simulating the specified user interaction event.
+	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
+	 */
+	notify(eventName?: string): void;
+
+	/**
+	 * An event-handler callback function, called when the window is about to be drawn.
+	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
+	 */
+	onDraw(): void;
+
+	/**
+	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
+	 * In Windows only.
+	 */
+	onShortcutKey(): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this element.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Shows this element.
+	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
+	 */
+	show(): void;
+
+}
+
+/**
+ * A pushbutton element containing a mouse-sensitive text string.
+ * Calls the onClick() callback if the control is clicked or if its notify() method is called.
+ */
+declare class Button {
+	/**
+	 * True if this element is active.
+	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
+	 */
+	active: boolean;
+
+	/**
+	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The boundaries of the element, in parent-relative coordinates.
+	 * Setting an element's size or location changes its bounds property, and vice-versa.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * A number of characters for which to reserve space when calculating the preferred size of the element.
+	 */
+	characters: number;
+
+	/**
+	 * An array of child elements.
+	 */
+	readonly children: Object[];
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
+	 */
+	readonly graphics: ScriptUIGraphics;
+
+	/**
+	 * The help string that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The number of pixels to indent the element during automatic layout.
+	 * Applies for column orientation and left alignment, or row orientation and top alignment.
+	 */
+	indent: number;
+
+	/**
+	 * The text justification style.
+	 * One of left, center, or right. Justification only works if this value is set on creation of the element.
+	 */
+	justify: string;
+
+	/**
+	 * The upper left corner of this element relative to its parent.
+	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
+	 */
+	location: Point;
+
+	/**
+	 * The maximum height and width to which the element can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * The minimum height and width to which the element can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size, used by layout managers to determine the best size for each element.
+	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
+	 * A Button object has no creation properties, but the third argument to the add() method that creates it can be the initial text value.
+	 */
+	properties: Object;
+
+	/**
+	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
+	 */
+	shortcutKey: string;
+
+	/**
+	 * The current dimensions of this element.
+	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
+	 */
+	size: Dimension;
+
+	/**
+	 * The text to display, a localizable string.
+	 */
+	text: string;
+
+	/**
+	 * The element type; "button".
+	 */
+	readonly type: string;
+
+	/**
+	 * True if this element is shown, false if it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this element relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Registers an event handler for a particular type of event occuring in this element.
+	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): Event;
+
+	/**
+	 * Hides this element.
+	 */
+	hide(): void;
+
+	/**
+	 * Sends a notification message, simulating the specified user interaction event.
+	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
+	 */
+	notify(eventName?: string): void;
+
+	/**
+	 * An event-handler callback function, called when the element acquires the keyboard focus.
+	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
+	 */
+	onActivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the element has been clicked
+	 */
+	onClick(): void;
+
+	/**
+	 * An event-handler callback function, called when the element loses the keyboard focus.
+	 * Called when the user moves the keyboard focus from the previously active control to another control.
+	 */
+	onDeactivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the window is about to be drawn.
+	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
+	 */
+	onDraw(): void;
+
+	/**
+	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
+	 * In Windows only.
+	 */
+	onShortcutKey(): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this element.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Shows this element.
+	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
+	 */
+	show(): void;
+
+}
+
+/**
+ * Amouse-sensitive pushbutton that displays an image instead of text.
+ * Calls the onClick() callback if the control is clicked or if its notify() method is called.
+ */
+declare class IconButton {
+	/**
+	 * True if this element is active.
+	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
+	 */
+	active: boolean;
+
+	/**
+	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The boundaries of the element, in parent-relative coordinates.
+	 * Setting an element's size or location changes its bounds property, and vice-versa.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * An array of child elements.
+	 */
+	readonly children: Object[];
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
+	 */
+	readonly graphics: ScriptUIGraphics;
+
+	/**
+	 * The help text that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The image object that defines the image to be drawn.
+	 */
+	image: ScriptUIImage;
+
+	/**
+	 * The number of pixels to indent the element during automatic layout.
+	 * Applies for column orientation and left alignment, or row orientation and top alignment.
+	 */
+	indent: number;
+
+	/**
+	 * The upper left corner of this element relative to its parent.
+	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
+	 */
+	location: Point;
+
+	/**
+	 * The maximum height and width to which the element can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * The minimum height and width to which the element can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size, used by layout managers to determine the best size for each element.
+	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
+	 * Creation properties of an IconButton object can include:
+	 * style:A string for the visual style, either "button", which has a visible border with a raised or 3D appearance, or "toolbutton", which has a flat appearance, appropriate for inclusion in a toolbar.
+	 */
+	properties: Object;
+
+	/**
+	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
+	 */
+	shortcutKey: string;
+
+	/**
+	 * The current dimensions of this element.
+	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
+	 */
+	size: Dimension;
+
+	/**
+	 * The element type; "iconbutton".
+	 */
+	readonly type: string;
+
+	/**
+	 * True if this element is shown, false if it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this element relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Registers an event handler for a particular type of event occuring in this element.
+	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): Event;
+
+	/**
+	 * Hides this element.
+	 */
+	hide(): void;
+
+	/**
+	 * Sends a notification message, simulating the specified user interaction event.
+	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
+	 */
+	notify(eventName?: string): void;
+
+	/**
+	 * An event-handler callback function, called when the element acquires the keyboard focus.
+	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
+	 */
+	onActivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the element has been clicked.
+	 */
+	onClick(): void;
+
+	/**
+	 * An event-handler callback function, called when the element loses the keyboard focus.
+	 * Called when the user moves the keyboard focus from the previously active control to another control.
+	 */
+	onDeactivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the window is about to be drawn.
+	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
+	 */
+	onDraw(): void;
+
+	/**
+	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
+	 * In Windows only.
+	 */
+	onShortcutKey(): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this element.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Shows this element.
+	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
+	 */
+	show(): void;
+
+}
+
+/**
+ * An editable text field that the user can select and change.
+ * Calls the onChange() callback if the text is changed and the user types Enter or the control loses focus, or if its notify() method is called. Calls the onChanging() callback when any change is made to the text. The textselection property contains currently selected text.
+ */
+declare class EditText {
+	/**
+	 * True if this element is active.
+	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
+	 */
+	active: boolean;
+
+	/**
+	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The boundaries of the element, in parent-relative coordinates.
+	 * Setting an element's size or location changes its bounds property, and vice-versa.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * A number of characters for which to reserve space when calculating the preferred size of the element.
+	 */
+	characters: number;
+
+	/**
+	 * An array of child elements.
+	 */
+	readonly children: Object[];
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
+	 */
+	readonly graphics: ScriptUIGraphics;
+
+	/**
+	 * The help text that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The number of pixels to indent the element during automatic layout.
+	 * Applies for column orientation and left alignment, or row orientation and top alignment.
+	 */
+	indent: number;
+
+	/**
+	 * The text justification style.
+	 * One of left, center, or right. Justification only works if this value is set on creation of the element.
+	 */
+	justify: string;
+
+	/**
+	 * The upper left corner of this element relative to its parent.
+	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
+	 */
+	location: Point;
+
+	/**
+	 * The maximum height and width to which the element can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * The minimum height and width to which the element can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size, used by layout managers to determine the best size for each element.
+	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
+	 * Creation properties of an EditText object can include:
+	 * multiline: When false (the default), the control displays a single line of text. When true, the control displays multiple lines, in which case the text wraps within the width of the control.
+	 * readonly: When false (the default),the control accepts text input. When true, the control does not accept input but only displays the contents of the text property.
+	 * noecho: When false (the default), the control displays input text. When true, the control does not display input text (used for password input fields).
+	 * enterKeySignalsOnChange: When false (the default), the control signals an onChange event when the editable text is changed and the control loses the keyboard focus (that is, the user tabs to another control, clicks outside the control, or types Enter). When true, the control only signals an onChange() event when the editable text is changed and the user types Enter; other changes to the keyboard focus do not signal the event.
+	 * wantReturn: Only applies to multiple line edit controls in ScriptUI Version 6.0 or later. When true the RETURN/ENTER keystroke is considered as text-input advancing the cursor to the next line. The default value is false.
+	 */
+	properties: Object;
+
+	/**
+	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
+	 */
+	shortcutKey: string;
+
+	/**
+	 * The current dimensions of this element.
+	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
+	 */
+	size: Dimension;
+
+	/**
+	 * The current text displayed in the field, a localizable string.
+	 */
+	text: string;
+
+	/**
+	 * The currently selected text, or the empty string if there is no text selected.
+	 * Setting the value replaces the current text selection and modifies the value of the text property. If there is no current selection, inserts the new value into the text string at the current insertion point. The textselection value is reset to an empty string after it modifies the text value. Note that setting the textselection property before the element’s parent Window exists is an undefined operation.
+	 */
+	textselection: string;
+
+	/**
+	 * The element type; "edittext".
+	 */
+	readonly type: string;
+
+	/**
+	 * True if this element is shown, false if it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this element relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Registers an event handler for a particular type of event occuring in this element.
+	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): Event;
+
+	/**
+	 * Hides this element.
+	 */
+	hide(): void;
+
+	/**
+	 * Sends a notification message, simulating the specified user interaction event.
+	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
+	 */
+	notify(eventName?: string): void;
+
+	/**
+	 * An event-handler callback function, called when the element acquires the keyboard focus.
+	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
+	 */
+	onActivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the content of the element has been changed
+	 * The handler is called only when the change is complete—that is, when focus moves to another control, or the user types Enter. The exact behavior depends on the creation parameter enterKeySignalsOnChange;see the properties property.
+	 */
+	onChange(): void;
+
+	/**
+	 * An event-handler callback function, called when the content of the element is in the process of changing
+	 * The handler is called for each keypress while this control has the input focus.
+	 */
+	onChanging(): void;
+
+	/**
+	 * An event-handler callback function, called when the element loses the keyboard focus.
+	 * Called when the user moves the keyboard focus from the previously active control to another control.
+	 */
+	onDeactivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the window is about to be drawn.
+	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
+	 */
+	onDraw(): void;
+
+	/**
+	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
+	 * In Windows only.
+	 */
+	onShortcutKey(): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this element.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Shows this element.
+	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
+	 */
+	show(): void;
+
+}
+
+/**
+ * Displays a list of choices, represented by ListItem objects.
+ * When you create the object, you specify whether it allows the user to select only one or multiple items. If a list contains more items than can be displayed in the available area, a scrollbar may appear that allows the user to scroll through all the list items.You can specify the items on creation of the list object, or afterward using the list object’s add() method. You can remove items programmatically with the list object’s remove() and removeAll() methods. You can create a list box with multiple columns; in this case, each row is a selectable choice, and each ListItem represents one row.
+ */
+declare class ListBox {
+	/**
+	 * True if this element is active.
+	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
+	 */
+	active: boolean;
+
+	/**
+	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The boundaries of the element, in parent-relative coordinates.
+	 * Setting an element's size or location changes its bounds property, and vice-versa.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * An array of child ListItem elements.
+	 */
+	readonly children: Object[];
+
+	/**
+	 * For a multi-column list box, the column properties.
+	 * A JavaScript object with two read-only properties whose values are set by the creation parameters:
+	 * titles: An array of column title strings, whose length matches the number of columns specified at creation.
+	 * preferredWidths: An array of column widths, whose length matches the number of columns specified at creation.
+	 * visible: An array of boolean visible attributes, whose length matches the number of columns specified at creation.This property can be used to show/hide a column. Avaiblable in ScriptUI Version 6.0 or later provided ScriptUI.frameworkName == 'Flex'.
+	 */
+	readonly columns: Object;
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
+	 */
+	readonly graphics: ScriptUIGraphics;
+
+	/**
+	 * The help text that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The number of pixels to indent the element during automatic layout.
+	 * Applies for column orientation and left alignment, or row orientation and top alignment.
+	 */
+	indent: number;
+
+	/**
+	 * The width and height in pixels of each item in the list.
+	 * Used by auto-layout to determine the preferredSize of the list, if not otherwise specified. If not set explicitly, the size of each item is set to match the largest height and width among all items in the list
+	 */
+	itemSize: Dimension;
+
+	/**
+	 * The array of choice items displayed in the list.
+	 * Access this array with a 0-based index. To obtain the number of items in the list, use items.length.The objects are created when items are specified on creation of the parent list object, or afterward using the list control’s add() method. Each item has a selected property that is true when it is in the selected state.
+	 */
+	readonly items: ListItem[];
+
+	/**
+	 * The upper left corner of this element relative to its parent.
+	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
+	 */
+	location: Point;
+
+	/**
+	 * The maximum height and width to which the element can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * The minimum height and width to which the element can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size, used by layout managers to determine the best size for each element.
+	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the control (properties used only when the element is created).
+	 * Creation properties of a ListBox object can include:
+	 * multiselect: When false (the default), only one item can be selected. When true, multiple items can be selected.
+	 * items: An array of strings for the text of each list item. An item object is created for each item. An item with the text string "-" creates a separator item. Supply this property, or the items argument to the add() method, not both. This form is most useful for elements defined using Resource Specifications.
+	 * numberOfColumns: A number of columns in which to display the items; default is 1. When there are multiple columns, each ListItem object represents a selectable row. Its text and image values specify the label in the first column, and the subitems property specifies the labels in the additional columns.
+	 * showHeaders: True to display column titles.
+	 * columnWidths: An array of numbers for the preferred width in pixels of each column.
+	 * columnTitles: A corresponding array of strings for the title of each column, to be shown if showHeaders is true.
+	 */
+	properties: Object;
+
+	/**
+	 * The currently selected item for a single-selection list, or an array of items for current selection in a multi-selection list.
+	 * Setting this value causes the selected item to be highlighted and to be scrolled into view if necessary. If no items are selected, the value is null. Set to null to deselect all items. You can set the value using the index of an item or an array of indices, rather than object references. If set to an index value that is out of range, the operation is ignored. When set with index values, the property still returns object references.
+	 * If you set the value to an array for a single-selection list, only the first item in the array is selected.
+	 * If you set the value to a single item for a multi-selection list, that item is added to the current selection.
+	 */
+	selection: ListItem;
+
+	/**
+	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
+	 */
+	shortcutKey: string;
+
+	/**
+	 * The current dimensions of this element.
+	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
+	 */
+	size: Dimension;
+
+	/**
+	 * The element type; "listbox".
+	 */
+	readonly type: string;
+
+	/**
+	 * True if this element is shown, false if it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this element relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Adds an item to the choices in this list.
+	 * Returns the item control object. If this is a multi-column list box, each added ListItem represents one selectable row.Its text and image values specify the label in the first column, and the subitems property specifies the labels in the additional columns.
+	 * @param type The type of the child element, the string "item".
+	 * @param text The localizable text label for the item.
+	 */
+	add(type: string, text?: string): ListItem;
+
+	/**
+	 * Registers an event handler for a particular type of event occuring in this element.
+	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): Event;
+
+	/**
+	 * Retrieves an item object from the list that has a given text label.
+	 * @param text The text string to match.
+	 */
+	find(text: string): ListItem;
+
+	/**
+	 * Hides this element.
+	 */
+	hide(): void;
+
+	/**
+	 * Sends a notification message, simulating the specified user interaction event.
+	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
+	 */
+	notify(eventName?: string): void;
+
+	/**
+	 * An event-handler callback function, called when the element acquires the keyboard focus.
+	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
+	 */
+	onActivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the content of the element has been changed
+	 */
+	onChange(): void;
+
+	/**
+	 * An event-handler callback function, called when the element loses the keyboard focus.
+	 * Called when the user moves the keyboard focus from the previously active control to another control.
+	 */
+	onDeactivate(): void;
+
+	/**
+	 * An event-handler callback function, called when an item in the listbox is double-clicked
+	 * Check the selection property to identify the item that was double-clicked.
+	 */
+	onDoubleClick(): void;
+
+	/**
+	 * An event-handler callback function, called when the window is about to be drawn.
+	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
+	 */
+	onDraw(): void;
+
+	/**
+	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
+	 * In Windows only.
+	 */
+	onShortcutKey(): void;
+
+	/**
+	 * Removes a child item from the list.
+	 * @param what The item or child to remove, specified by 0-based index, text value, or as a ListItem object.
+	 */
+	remove(what: any): void;
+
+	/**
+	 * Removes all child items from the list.
+	 */
+	removeAll(): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this element.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Shows this element.
+	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
+	 */
+	show(): void;
+
+}
+
+/**
+ * Displays a single visible item. When you click the control, a list drops down or pops up, and allows you to select one of the other items in the list.
+ * Drop-down lists can have nonselectable separator items for visually separating groups of related items, as in a menu. You can specify the items on creation of the list object, or afterward using the list object’s add() method. You can remove items programmatically with the list object’s remove() and removeAll() methods. Calls the onChange() callback if the item selection is changed or if its notify() method is called.
+ */
+declare class DropDownList {
+	/**
+	 * True if this element is active.
+	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
+	 */
+	active: boolean;
+
+	/**
+	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The boundaries of the element, in parent-relative coordinates.
+	 * Setting an element's size or location changes its bounds property, and vice-versa.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * An array of child elements.
+	 */
+	readonly children: Object[];
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
+	 */
+	readonly graphics: ScriptUIGraphics;
+
+	/**
+	 * The help text that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The number of pixels to indent the element during automatic layout.
+	 * Applies for column orientation and left alignment, or row orientation and top alignment.
+	 */
+	indent: number;
+
+	/**
+	 * The width and height in pixels of each item in the list.
+	 * Used by auto-layout to determine the preferredSize of the list, if not otherwise specified. If not set explicitly, the size of each item is set to match the largest height and width among all items in the list
+	 */
+	itemSize: Dimension;
+
+	/**
+	 * The array of choice items displayed in the drop-down or pop-up list.
+	 * Access this array with a 0-based index. To obtain the number of items in the list, use items.length.The objects are created when items are specified on creation of the parent list object, or afterward using the list control’s add() method. Items in a drop-down list can be of type separator, in which case they cannot be selected, and are shown as a horizontal line. Each item has a selected property that is true when it is in the selected state.
+	 */
+	readonly items: ListItem[];
+
+	/**
+	 * The upper left corner of this element relative to its parent.
+	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
+	 */
+	location: Point;
+
+	/**
+	 * The maximum height and width to which the element can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * The minimum height and width to which the element can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size, used by layout managers to determine the best size for each element.
+	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
+	 * Creation properties of a DropDownList object can include:
+	 * items: An array of strings for the text of each list item. An item object is created for each item. An item with the text string "-" creates a separator item. Supply this property, or the items argument to the add() method, not both. This form is most useful for elements defined using Resource Specifications.
+	 */
+	properties: Object;
+
+	/**
+	 * The currently selectedlist item.
+	 * Setting this value causes the selected item to be highlighted and to be scrolled into view if necessary. If no items are selected, the value is null. Set to null to deselect all items.You can set the value using the index of an item, rather than an object reference. If set to an index value that is out of range, the operation is ignored. When set with an index value, the property still returns an object reference.
+	 */
+	selection: ListItem;
+
+	/**
+	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
+	 */
+	shortcutKey: string;
+
+	/**
+	 * The current dimensions of this element.
+	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
+	 */
+	size: Dimension;
+
+	/**
+	 * The element type; "dropdownlist".
+	 */
+	readonly type: string;
+
+	/**
+	 * True if this element is shown, false if it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this element relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Adds an item or separator to the choices in this list.
+	 * Returns the item control object for type="item", or null for type="separator".
+	 * @param type The type of the child element. Either item (a basic, selectable item with a text label) or separator
+	 * @param text The localizable text label for the item.
+	 */
+	add(type: string, text?: string): ListItem;
+
+	/**
+	 * Registers an event handler for a particular type of event occuring in this element.
+	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): Event;
+
+	/**
+	 * Retrieves an item object from the list that has a given text label.
+	 * @param text The text string to match.
+	 */
+	find(text: string): ListItem;
+
+	/**
+	 * Hides this element.
+	 */
+	hide(): void;
+
+	/**
+	 * Sends a notification message, simulating the specified user interaction event.
+	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
+	 */
+	notify(eventName?: string): void;
+
+	/**
+	 * An event-handler callback function, called when the element acquires the keyboard focus.
+	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
+	 */
+	onActivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the content of the element has been changed
+	 */
+	onChange(): void;
+
+	/**
+	 * An event-handler callback function, called when the element loses the keyboard focus.
+	 * Called when the user moves the keyboard focus from the previously active control to another control.
+	 */
+	onDeactivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the window is about to be drawn.
+	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
+	 */
+	onDraw(): void;
+
+	/**
+	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
+	 * In Windows only.
+	 */
+	onShortcutKey(): void;
+
+	/**
+	 * Removes a child item from the list.
+	 * @param what The item or child to remove, specified by 0-based index, text value, or as a ListItem object.
+	 */
+	remove(what: any): void;
+
+	/**
+	 * Removes all child items from the list.
+	 */
+	removeAll(): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this element.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Shows this element.
+	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
+	 */
+	show(): void;
+
+}
+
+/**
+ * An item in a list box, drop-down list, or tree view.
+ * You can specify initial items in the creation parameters when creating the parent list. Create new items using the add() method (ListBox.add(), DropDownList.add(), TreeView.add()) in the parent list with control type="item", or, for DropDownList controls, type="separator".For a multi-column list box, the object represents one selectable row. Its text and image values specify the label in the first column, and the subitems property specifies the labels in the additional columns.
+ */
+declare class ListItem {
+	/**
+	 * The checked state of an item in a list.
+	 * When true, the item is marked with the platform-appropriate checkmark. When false, no checkmark is drawn, but space is reserved for it in the left margin, so that the item lines up with other checkable items. When undefined, no space is reserved for a checkmark.
+	 */
+	checked: boolean;
+
+	/**
+	 * The expansion state of an item of type node that is a child of a TreeView list control.
+	 * When true, the item is in the expanded state and its children are shown, when false, it is collapsed and children are hidden.
+	 */
+	expanded: boolean;
+
+	/**
+	 * An image object for an icon to display in the item.
+	 * When specified, the image appropriate to the selections state is drawn to the left of the text label. If the parent is a multi-column list box, this describes the label in the first column. Labels in additional columns are described by the subitems property.
+	 */
+	image: ScriptUIImage;
+
+	/**
+	 * The 0-based index of this item in the items collection of its parent list control.
+	 */
+	readonly index: number;
+
+	/**
+	 * The parent element, a list control.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * An object that contains one or more creation properties of the item (properties used only when the element is created).
+	 * A ListItem object has no creation properties.
+	 */
+	properties: Object;
+
+	/**
+	 * The selection state of this item.
+	 * When true, the item is part of the selection for its parent list. When false, the item is not selected. Set to true to select this item in a single-selection list, or to add it to the selection array for a multi-selection list.
+	 */
+	selected: boolean;
+
+	/**
+	 * When the parent is a multi-column ListBox, this describes the labels for this selectable row in additional columns.
+	 * A array of JavaScript objects whose length is one less than the number of columns. The first member describes the label in the second column. Each member object has two properties, of which you can specify one or both:
+	 * text: A display string for the corresponding label.
+	 * image: An ScriptUIImage object for the corresponding label.
+	 */
+	readonly subItems: any[];
+
+	/**
+	 * The label text to display for the item, a localizable string.
+	 * If the parent is a multi-column list box, this describes the label in the first column. Labels in additional columns are described by the subitems property.
+	 */
+	text: string;
+
+	/**
+	 * The element type.
+	 * Normally "item", but an item whose parent is a DropDownList control can have type "separator". A separator item is not mouse-sensitive and is drawn as a horizontal line across the drop-down or pop-up menu.
+	 */
+	readonly type: string;
+
+}
+
+/**
+ * A dual-state control showing a box that has a checkmark when the value is true, and is empty when the value is false.
+ * Calls the onClick() callback if the control is clicked or if its notify() method is called.
+ */
+declare class Checkbox {
+	/**
+	 * True if this element is active.
+	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
+	 */
+	active: boolean;
+
+	/**
+	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The boundaries of the element, in parent-relative coordinates.
+	 * Setting an element's size or location changes its bounds property, and vice-versa.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * A number of characters for which to reserve space when calculating the preferred size of the element.
+	 */
+	characters: number;
+
+	/**
+	 * An array of child elements.
+	 */
+	readonly children: Object[];
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
+	 */
+	readonly graphics: ScriptUIGraphics;
+
+	/**
+	 * The help text that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The number of pixels to indent the element during automatic layout.
+	 * Applies for column orientation and left alignment, or row orientation and top alignment.
+	 */
+	indent: number;
+
+	/**
+	 * The default text justification style for child text elements.
+	 * One of left, center, or right. Justification only works if this value is set on creation of the element.
+	 */
+	justify: string;
+
+	/**
+	 * The upper left corner of this element relative to its parent.
+	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
+	 */
+	location: Point;
+
+	/**
+	 * The maximum height and width to which the element can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * The minimum height and width to which the element can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size, used by layout managers to determine the best size for each element.
+	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the item (properties used only when the element is created).
+	 * A CheckBox object has no creation properties. The third argument to the add() method that creates it is the text to be displayed.
+	 */
+	properties: Object;
+
+	/**
+	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
+	 */
+	shortcutKey: string;
+
+	/**
+	 * The current dimensions of this element.
+	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
+	 */
+	size: Dimension;
+
+	/**
+	 * The text to display, a localizable string.
+	 */
+	text: string;
+
+	/**
+	 * The element type; "checkbox".
+	 */
+	readonly type: string;
+
+	/**
+	 * The selection state of the control.
+	 * When true, the control is in the selected or set state and displays the check mark. When false, shows an empty box.
+	 */
+	value: boolean;
+
+	/**
+	 * True if this element is shown, false if it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this element relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Registers an event handler for a particular type of event occuring in this element.
+	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): Event;
+
+	/**
+	 * Hides this element.
+	 */
+	hide(): void;
+
+	/**
+	 * Sends a notification message, simulating the specified user interaction event.
+	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
+	 */
+	notify(eventName?: string): void;
+
+	/**
+	 * An event-handler callback function, called when the element acquires the keyboard focus.
+	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
+	 */
+	onActivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the element has been clicked.
+	 */
+	onClick(): void;
+
+	/**
+	 * An event-handler callback function, called when the element loses the keyboard focus.
+	 * Called when the user moves the keyboard focus from the previously active control to another control.
+	 */
+	onDeactivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the window is about to be drawn.
+	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
+	 */
+	onDraw(): void;
+
+	/**
+	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
+	 * In Windows only.
+	 */
+	onShortcutKey(): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this element.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Shows this element.
+	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
+	 */
+	show(): void;
+
+}
+
+/**
+ * A scrollbar with a draggable scroll indicator and stepper buttons to move the indicator.
+ * The scrollbar control has a horizontal orientation if the width is greater than the height at creation time, or vertical if its height is greater than its width.
+ * Calls the onChange() callback after the position of the indicator is changed or if its notify() method is called. Calls the onChanging() callback repeatedly while the user is moving the indicator. Scrollbars are often created with an associated EditText field to display the current value of the scrollbar, and to allow setting the scrollbar's position to a specific value.
+ */
+declare class Scrollbar {
+	/**
+	 * True if this element is active.
+	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
+	 */
+	active: boolean;
+
+	/**
+	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The boundaries of the element, in parent-relative coordinates.
+	 * Setting an element's size or location changes its bounds property, and vice-versa.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * An array of child elements.
+	 */
+	readonly children: Object[];
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
+	 */
+	readonly graphics: ScriptUIGraphics;
+
+	/**
+	 * The help text that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The number of pixels to indent the element during automatic layout.
+	 * Applies for column orientation and left alignment, or row orientation and top alignment.
+	 */
+	indent: number;
+
+	/**
+	 * The amount to increment or decrement a scrollbar indicator's position when the user clicks ahead or behind the moveable element.
+	 * Default is 20% of the range between the maxvalue and minvalue property values.
+	 */
+	jumpdelta: number;
+
+	/**
+	 * The upper left corner of this element relative to its parent.
+	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
+	 */
+	location: Point;
+
+	/**
+	 * The maximum height and width to which the element can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * The maximum value allowed in the value property.
+	 * Together with minvalue, sets the scrolling range. Default is 100.
+	 */
+	maxvalue: number;
+
+	/**
+	 * The minimum height and width to which the element can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The minimum value allowed in the value property.
+	 * Together with  maxvalue, sets the scrolling range.Default is 0.
+	 */
+	minvalue: number;
+
+	/**
+	 * The parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size, used by layout managers to determine the best size for each element.
+	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
+	 * A Scrollbar object has no creation properties. The third argument of the add() method that creates it is the initial value, and the fourth and fifth arguments are the minimum and maximum values of the range.
+	 */
+	properties: Object;
+
+	/**
+	 * The key sequence that invokes the  onShortcutKey() callback for this element (in Windows only).
+	 */
+	shortcutKey: string;
+
+	/**
+	 * The current dimensions of this element.
+	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
+	 */
+	size: Dimension;
+
+	/**
+	 * The amount by which to increment or decrement a scrollbar element's position when the user clicks a stepper button.
+	 */
+	stepdelta: number;
+
+	/**
+	 * The element type, "scrollbar".
+	 */
+	readonly type: string;
+
+	/**
+	 * The current position of the indicator.
+	 * If set to a value outside the range specified by minvalue and maxvalue, it is automatically reset to the closest boundary.
+	 */
+	value: number;
+
+	/**
+	 * True if this element is shown, false if it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this element relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Registers an event handler for a particular type of event occuring in this element.
+	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): Event;
+
+	/**
+	 * Hides this element.
+	 */
+	hide(): void;
+
+	/**
+	 * Sends a notification message, simulating the specified user interaction event.
+	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
+	 */
+	notify(eventName?: string): void;
+
+	/**
+	 * An event-handler callback function, called when the element acquires the keyboard focus.
+	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
+	 */
+	onActivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the user has finished dragging the position indicator, or has clicked the control.
+	 */
+	onChange(): void;
+
+	/**
+	 * An event-handler callback function, called when the content of the element is in the process of changing
+	 * The handler is called for any motion of the position indicator while this control has the input focus.
+	 */
+	onChanging(): void;
+
+	/**
+	 * An event-handler callback function, called when the element loses the keyboard focus.
+	 * Called when the user moves the keyboard focus from the previously active control to another control.
+	 */
+	onDeactivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the window is about to be drawn.
+	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
+	 */
+	onDraw(): void;
+
+	/**
+	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
+	 * In Windows only.
+	 */
+	onShortcutKey(): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this element.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Shows this element.
+	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
+	 */
+	show(): void;
+
+}
+
+/**
+ * A dual-state control, grouped with other radiobuttons, of which only one can be in the selected state.
+ * Shows the selected state when value=true, empty when value=false. Calls the onClick() callback if the control is clicked or if its notify() method is called.
+ */
+declare class RadioButton {
+	/**
+	 * True if this element is active.
+	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
+	 */
+	active: boolean;
+
+	/**
+	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The boundaries of the element, in parent-relative coordinates.
+	 * Setting an element's size or location changes its bounds property, and vice-versa.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * A number of characters for which to reserve space when calculating the preferred size of the element.
+	 */
+	characters: number;
+
+	/**
+	 * An array of child elements.
+	 */
+	readonly children: Object[];
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw event.
+	 */
+	readonly graphics: ScriptUIGraphics;
+
+	/**
+	 * The help text that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The number of pixels to indent the element during automatic layout.
+	 * Applies for column orientation and left alignment, or row orientation and top alignment.
+	 */
+	indent: number;
+
+	/**
+	 * The default text justification style for child text elements.
+	 * One of left, center, or right. Justification only works if this value is set on creation of the element.
+	 */
+	justify: string;
+
+	/**
+	 * The upper left corner of this element relative to its parent.
+	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
+	 */
+	location: Point;
+
+	/**
+	 * The maximum height and width to which the element can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * The minimum height and width to which the element can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size, used by layout managers to determine the best size for each element.
+	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes. A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
+	 * A RadioButton object has no creation properties. The third argument of the add() method that creates can be the label text.
+	 */
+	properties: Object;
+
+	/**
+	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
+	 */
+	shortcutKey: string;
+
+	/**
+	 * The current dimensions of this element.
+	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
+	 */
+	size: Dimension;
+
+	/**
+	 * The label text for this button, a localizable string.
+	 */
+	text: string;
+
+	/**
+	 * The element type; "radiobutton".
+	 */
+	readonly type: string;
+
+	/**
+	 * The selection state of this button, selected when true.
+	 */
+	value: boolean;
+
+	/**
+	 * True if this element is shown, false if it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this element relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Registers an event handler for a particular type of event occuring in this element.
+	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): Event;
+
+	/**
+	 * Hides this element.
+	 */
+	hide(): void;
+
+	/**
+	 * Sends a notification message, simulating the specified user interaction event.
+	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
+	 */
+	notify(eventName?: string): void;
+
+	/**
+	 * An event-handler callback function, called when the element acquires the keyboard focus.
+	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
+	 */
+	onActivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the element has been clicked.
+	 */
+	onClick(): void;
+
+	/**
+	 * An event-handler callback function, called when the element loses the keyboard focus.
+	 * Called when the user moves the keyboard focus from the previously active control to another control.
+	 */
+	onDeactivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the window is about to be drawn.
+	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
+	 */
+	onDraw(): void;
+
+	/**
+	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
+	 * In Windows only.
+	 */
+	onShortcutKey(): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this element.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Shows this element.
+	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
+	 */
+	show(): void;
+
+}
+
+/**
+ * A slider bar that indicates a numeric value with a moveable position indicator.
+ * All slider controls have a horizontal orientation. Calls the onChange() callback after the position of the indicator is changed or if its notify() method is called. Calls the onChanging() callback repeatedly while the user is moving the indicator. The value property contains the current position of the indicator within the range of minvalue to maxvalue.
+ */
+declare class Slider {
+	/**
+	 * True if this element is active.
+	 * An active control is the one with keyboard focus—that is, the one that accepts keystrokes, or in the case of a Button, is selected when the user types Return or Enter in Windows, or the space bar in Mac OS.
+	 */
+	active: boolean;
+
+	/**
+	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The boundaries of the element, in parent-relative coordinates.
+	 * Setting an element's size or location changes its bounds property, and vice-versa.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * An array of child elements.
+	 */
+	readonly children: Object[];
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
+	 */
+	readonly graphics: ScriptUIGraphics;
+
+	/**
+	 * The help text that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The number of pixels to indent the element during automatic layout.
+	 * Applies for column orientation and left alignment, or row orientation and top alignment.
+	 */
+	indent: number;
+
+	/**
+	 * The upper left corner of this element relative to its parent.
+	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
+	 */
+	location: Point;
+
+	/**
+	 * The maximum height and width to which the element can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * The maximum value allowed in the value property.
+	 * Together with minvalue, sets therange.Default is 100.
+	 */
+	maxvalue: number;
+
+	/**
+	 * The minimum height and width to which the element can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The minimum value allowed in the value property.
+	 * Together with maxvalue, sets the range.Default is 0.
+	 */
+	minvalue: number;
+
+	/**
+	 * The parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size, used by layout managers to determine the best size for each element.
+	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the container (properties used only when the element is created).
+	 * A Slider object has no creation properties. The third argument of the add() method that creates it is the initial value, and the fourth and fifth arguments are the minimum and maximum values of the range.
+	 */
+	properties: Object;
+
+	/**
+	 * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
+	 */
+	shortcutKey: string;
+
+	/**
+	 * The current dimensions of this element.
+	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
+	 */
+	size: Dimension;
+
+	/**
+	 * The element type, "slider".
+	 */
+	readonly type: string;
+
+	/**
+	 * The current position of the indicator.
+	 * If set to a value outside the range specified by minvalue and maxvalue, it is automatically reset to the closest boundary.
+	 */
+	value: number;
+
+	/**
+	 * True if this element is shown, false if it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this element relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Registers an event handler for a particular type of event occuring in this element.
+	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): Event;
+
+	/**
+	 * Hides this element.
+	 */
+	hide(): void;
+
+	/**
+	 * Sends a notification message, simulating the specified user interaction event.
+	 * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
+	 */
+	notify(eventName?: string): void;
+
+	/**
+	 * An event-handler callback function, called when the element acquires the keyboard focus.
+	 * Called when the user gives the control the keyboard focus by clicking it or tabbing into it.
+	 */
+	onActivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the user has finished dragging the position indicator, or has clicked the control.
+	 */
+	onChange(): void;
+
+	/**
+	 * An event-handler callback function, called when the content of the element is in the process of changing
+	 * The handler is called for any motion of the position indicator while this control has the input focus.
+	 */
+	onChanging(): void;
+
+	/**
+	 * An event-handler callback function, called when the element loses the keyboard focus.
+	 * Called when the user moves the keyboard focus from the previously active control to another control.
+	 */
+	onDeactivate(): void;
+
+	/**
+	 * An event-handler callback function, called when the window is about to be drawn.
+	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
+	 */
+	onDraw(): void;
+
+	/**
+	 * An event-handler callback function, called when the element's shortcutKey sequence is typed in the active window.
+	 * In Windows only.
+	 */
+	onShortcutKey(): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this element.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Shows this element.
+	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
+	 */
+	show(): void;
+
+}
+
+
+/**
+ * A drawing pen that defines a color and line width used to stroke paths.
+ * Create with ScriptUIGraphics.newPen(). Use as a value of  foregroundColor properties, and pass as an argument to drawString() and strokePath() methods.
+ */
+declare class ScriptUIPen {
+	/**
+	 * The pen color.
+	 * The paint color to use when the type is SOLID_COLOR. An array in the form [R, B, G, A] specifying the red, green, blue values of the color and the opacity (alpha channel) value as numbers in the range [0.0..1.0]. An opacity of 0 is fully transparent, and an opacity of 1 is fully opaque.
+	 */
+	readonly color: number[];
+
+	/**
+	 * The pixel width of the drawing line.
+	 */
+	lineWidth: number;
+
+	/**
+	 * The theme name.
+	 * The name of a color theme to use for drawing when the type is THEME_COLOR. Theme colors are defined by the host application.
+	 */
+	readonly theme: string;
+
+	/**
+	 * The pen type, solid or theme.
+	 * One of these constants: ScriptUIGraphics.PenType.SOLID_COLOR or ScriptUIGraphics.PenType.THEME_COLOR
+	 */
+	readonly type: string;
+
+}
+
+/**
+ * A painting brush that encapsulates a color or pattern used to fill paths.
+ * Create with ScriptUIGraphics.newBrush(). Use as a value of  backgroundColor properties, and pass as an argument to the fillPath() method.
+ */
+declare class ScriptUIBrush {
+	/**
+	 * The brush color.
+	 * The paint color to use when the type is SOLID_COLOR. An array in the form [R, B, G, A] specifying the red, green, blue values of the color and the opacity (alpha channel) value as numbers in the range [0.0..1.0]. An opacity of 0 is fully transparent, and an opacity of 1 is fully opaque.
+	 */
+	readonly color: number[];
+
+	/**
+	 * The theme name.
+	 * The name of a color theme to use for drawing when the type is THEME_COLOR. Theme colors are defined by the host application.
+	 */
+	readonly theme: string;
+
+	/**
+	 * The brush type, solid or theme.
+	 * One of these constants: ScriptUIGraphics.BrushType.SOLID_COLOR or ScriptUIGraphics.BrushType.THEME_COLOR
+	 */
+	readonly type: number;
+
+}
+
+/**
+ * A helper object that encapsulates a drawing path for a figure to be drawn into a window or control.
+ * Create with the newPath(), moveto(), lineto(), rectPath(), and ellipsePath() methods.Used as value of currentPath, where it is acted upon by methods such as closePath().Pass as optional argument to fillPath() and strokePath(), which otherwise act upon the current path.
+ */
+declare class ScriptUIPath {
+}
+
+/**
+ * An object used to draw custom graphics, found in the graphics property of window, container, and control objects.
+ * Allows a script to customize aspects of the element’s appearance, such as the color and font. Use an onDraw callback function to set these properties or call the functions.All measurements are in pixels.
+ */
+declare class ScriptUIGraphics {
+	/**
+	 * Contains the enumerated constants for the type argument of newBrush().
+	 * Type constants are: SOLID_COLOR, THEME_COLOR.
+	 */
+	static readonly BrushType: Object;
+
+	/**
+	 * Contains the enumerated constants for the type argument of newPen().
+	 * Type constants are: SOLID_COLOR, THEME_COLOR.
+	 */
+	static readonly PenType: Object;
+
+	/**
+	 * The background color for containers; for non-containers, the parent background color.
+	 * The paint color and style is defined in this brush object.This property is only supported for controls likedropdownlist, edittext, and listbox.
+	 */
+	backgroundColor: ScriptUIBrush;
+
+	/**
+	 * The current drawing path, encapsulated in a path object.
+	 */
+	readonly currentPath: ScriptUIPath;
+
+	/**
+	 * The current position in the current drawing path.
+	 */
+	readonly currentPoint: Point;
+
+	/**
+	 * The background color for containers when disabled or inactive; for non-containers, the parent background color.
+	 * The paint color and style is defined in this brush object.This property is only supported for controls likedropdownlist, edittext, and listbox.
+	 */
+	disabledBackgroundColor: ScriptUIBrush;
+
+	/**
+	 * The text color when the element is disabled or inactive.
+	 * The paint color and style is defined in this pen object.
+	 */
+	disabledForegroundColor: ScriptUIPen;
+
+	/**
+	 * The default font to use for displaying text.
+	 */
+	font: ScriptUIFont;
+
+	/**
+	 * The text color.
+	 * The paint color and style is defined in this pen object.
+	 */
+	foregroundColor: ScriptUIPen;
+
+	/**
+	 * Closes the current path.
+	 * Defines a line from the current postion (currentPoint) to the start point of the current path (the value of currentPath).
+	 */
+	closePath(): void;
+
+	/**
+	 * Draws a focus ring within a region of this element.
+	 * @param left The left coordinate of the region. Value is relative to the origin of this element.
+	 * @param top The top coordinate of the region. Value is relative to the origin of this element.
+	 * @param width The width of the region in pixels.
+	 * @param height The height of the region in pixels.
+	 */
+	drawFocusRing(left: number, top: number, width: number, height: number): void;
+
+	/**
+	 * Draws an image within a given region of the element.
+	 * Uses the version of the image that is appropriate to the element's current state.
+	 * @param image The image to draw. This object contains different versions of an image appropriate to various element states, such as a dimmed version for the disabled state.
+	 * @param left The left coordinate of the region, relative to the origin of this element.
+	 * @param top The top coordinate of the region, relative to the origin of this element.
+	 * @param width The width in pixels. If provided, the image is stretched or shrunk to fit. If omitted, uses the original image width.
+	 * @param height The height in pixels. If provided, the image is stretched or shrunk to fit. If omitted, uses the original image height.
+	 */
+	drawImage(image: ScriptUIImage, left: number, top: number, width?: number, height?: number): void;
+
+	/**
+	 * Draw the platform-specific control associated with this element.
+	 */
+	drawOSControl(): void;
+
+	/**
+	 * Draw a string of text starting at a given point in this element, using a given drawing pen and font.
+	 * @param text The text string.
+	 * @param pen The drawing pen to use.
+	 * @param x The left coordinate, relative to the origin of this element.
+	 * @param y The top coordinate, relative to the origin of this element.
+	 * @param font The font to use. Default is the  font value in this object.
+	 */
+	drawString(text: string, pen: ScriptUIPen, x: number, y: number, font?: ScriptUIFont): void;
+
+	/**
+	 * Defines an elliptical path within a given rectangular area in the currentPath object, which can be filled using fillPath() or stroked using strokePath().
+	 * Returns a Point object for the upper left corner of the area, which is the new currentPoint.
+	 * @param left The left coordinate of the region, relative to the origin of this element.
+	 * @param top The top coordinate of the region, relative to the origin of this element.
+	 * @param width The width of the region in pixels.
+	 * @param height The height of the region in pixels.
+	 */
+	ellipsePath(left: number, top: number, width: number, height: number): Point;
+
+	/**
+	 * Fills a path using a given painting brush.
+	 * @param brush The brush object that defines the fill color.
+	 * @param path The path object. Default is the currentPath.
+	 */
+	fillPath(brush: ScriptUIBrush, path?: ScriptUIPath): void;
+
+	/**
+	 * Adds a path segment to the currentPath.
+	 * The line is defined from the currentPoint to the specified destination point. Returns the Point objectfor the destination point, which becomes the new value of currentPoint.
+	 * @param x The X coordinate for the destination point, relative to the origin of this element.
+	 * @param y The Y coordinate for the destination point, relative to the origin of this element.
+	 */
+	lineTo(x: number, y: number): Point;
+
+	/**
+	 * Calculates the size needed to display a string using the given font.
+	 * Returns a Dimension object that contains the height and width of the string in pixels.
+	 * @param text The text string to measure.
+	 * @param font The font to use. Default is the font value in this object.
+	 * @param boundingWidth The bounding width.
+	 */
+	measureString(text: string, font?: ScriptUIFont, boundingWidth?: number): Dimension;
+
+	/**
+	 * Adds a given point to the currentPath, and makes it the current drawing position.
+	 * Returns the Point object which is the new value of currentPoint.
+	 * @param x The X coordinate for the new point, relative to the origin of this element.
+	 * @param y The Y coordinate for the new point, relative to the origin of this element.
+	 */
+	moveTo(x: number, y: number): Point;
+
+	/**
+	 * Creates a new painting brush object.
+	 * @param type The brush type, solid or theme. One of the constants ScriptUIGraphics.BrushType.SOLID_COLOR or ScriptUIGraphics.BrushType.THEME_COLOR.
+	 * @param color The brush color. If type is SOLID_COLOR, the color expressed as an array of three or four values, in the form [R, B, G, A] specifying the red, green, and blue values of the color and, optionally, the opacity (alpha channel). All values are numbers in the range [0.0..1.0]. An opacity of 0 is fully transparent, and an opacity of 1 is fully opaque. If the type is THEME_COLOR, the name string of the theme. Theme colors are defined by the host application.
+	 */
+	newBrush(type: number, color: number[]): ScriptUIBrush;
+
+	/**
+	 * Creates a new, empty path object.
+	 * Replaces any existing path in currentPath.
+	 */
+	newPath(): ScriptUIPath;
+
+	/**
+	 * Creates a new drawing pen object.
+	 * @param type The pen type, solid or theme. One of the constants ScriptUIGraphics.PenType.SOLID_COLOR or ScriptUIGraphics.PenType.THEME_COLOR.
+	 * @param color The pen color. If type is SOLID_COLOR, the color expressed as an array of three or four values, in the form [R, B, G, A] specifying the red, green, and blue values of the color and, optionally, the opacity (alpha channel). All values are numbers in the range [0.0..1.0]. An opacity of 0 is fully transparent, and an opacity of 1 is fully opaque. If the type is THEME_COLOR, the name string of the theme. Theme colors are defined by the host application.
+	 * @param width The width of the pen line in pixels. The line is centered around the current point. For example, if the value is 2, drawing a line from (0, 10) to (5, 10) paints the two rows of pixels directly above and below y-position 10.
+	 */
+	newPen(type: number, color: number[], width: number): ScriptUIPen;
+
+	/**
+	 * Defines a rectangular path in the currentPath object.
+	 * The rectangle can be filled using fillPath() or stroked using strokePath().Returns the Point objectfor the upper left corner of the rectangle, which becomes the new value of currentPoint.
+	 * @param left The left coordinate relative to the origin of this element.
+	 * @param top The top coordinate relative to the origin of this element.
+	 * @param width The width in pixels.
+	 * @param height The height in pixels.
+	 */
+	rectPath(left: number, top: number, width: number, height: number): Point;
+
+	/**
+	 * Strokes the path segments of a path with a given drawing pen.
+	 * @param pen The drawing pen that defines the color and line width.
+	 * @param path The path object. Default is the currentPath.
+	 */
+	strokePath(pen: ScriptUIPen, path?: ScriptUIPath): void;
+
+}
+
+/**
+ * Describes an input state at the time of the triggering  ScriptUIGraphics.onDraw() event.
+ * Contains properties that report whether the current control has the input focus, and the particular mouse button and keypress state. Passed in as argument to ScriptUIGraphics.onDraw().
+ */
+declare class DrawState {
+	/**
+	 * True if the Alt key is being pressed (in Windows only).
+	 */
+	readonly altKeyPressed: boolean;
+
+	/**
+	 * True if the Caps Lock key is being pressed.
+	 */
+	readonly capsLockKeyPressed: boolean;
+
+	/**
+	 * True if the Command key is being pressed (in Mac OS only).
+	 */
+	readonly cmdKeyPressed: boolean;
+
+	/**
+	 * True if the Ctrl key is being pressed.
+	 */
+	readonly ctrlKeyPressed: boolean;
+
+	/**
+	 * True if the element has the input focus.
+	 */
+	readonly hasFocus: boolean;
+
+	/**
+	 * True if the left mouse button is being pressed.
+	 */
+	readonly leftButtonPressed: boolean;
+
+	/**
+	 * True if the middle mouse button is being pressed.
+	 */
+	readonly middleButtonPressed: boolean;
+
+	/**
+	 * True if the cursor is hovering over this element.
+	 */
+	readonly mouseOver: boolean;
+
+	/**
+	 * True if the Num Lock key is being pressed.
+	 */
+	readonly numLockKeyPressed: boolean;
+
+	/**
+	 * True if the Option key is being pressed (in Mac OS only).
+	 */
+	readonly optKeyPressed: boolean;
+
+	/**
+	 * True if the right mouse button is being pressed.
+	 */
+	readonly rightButtonPressed: boolean;
+
+	/**
+	 * True if the Shift key is being pressed.
+	 */
+	readonly shiftKeyPressed: boolean;
+
+}
+
+/**
+ * Encapsulates the qualities of a font used to draw text into a control.
+ * Create with the newFont() method.Used as a value of font. Passed as an argument to drawString() and measureString().
+ */
+declare class ScriptUIFont {
+	/**
+	 * The font family name.
+	 */
+	readonly family: string;
+
+	/**
+	 * The complete font name, consisting of the family and style, if specified.
+	 */
+	readonly name: string;
+
+	/**
+	 * The font point size.
+	 */
+	readonly size: number;
+
+	/**
+	 * The font style. One of the constants in ScriptUIGraphics.FontStyle.
+	 */
+	readonly style: Object;
+
+	/**
+	 * The name of a substitution font, a fallback font to substitute for this font if the requested font family or style is not available.
+	 */
+	readonly substitute: string;
+
+}
+
+/**
+ * Encapsulates a set of images that can be drawn into a control.
+ * Different images can reflect the current state, such as a dimmed version for a disabled control. Create with the newImage() method. Passed as an argument to drawImage().
+ */
+declare class ScriptUIImage {
+	/**
+	 * The image format. One of: resource, JPEG, GIF, TIFF, PNG, or PICT (Macintosh).
+	 */
+	readonly format: string;
+
+	/**
+	 * The image name. Either the file name, or the resource name.
+	 */
+	readonly name: string;
+
+	/**
+	 * The full path to the file that contains the image.
+	 */
+	readonly pathname: string;
+
+	/**
+	 * The image size in pixels.
+	 */
+	readonly size: Dimension;
+
+}
+
+
+/**
+ * A container for other controls within a window.
+ * A group can specify layout options for its child elements. Hiding a group hides all its children. Making it visible makes visible those children that are not individually hidden.
+ */
+declare class Group {
+	/**
+	 * Tells the layout manager how unlike-sized children of this container should be aligned within a column or row.
+	 * Order of creation determines which children are at the top of a column or the left of a row; the earlier a child is created, the closer it is to the top or left of its column or row. If defined, alignment for a child element overrides the alignChildren setting for the parent container. See alignment property for values.
+	 */
+	alignChildren: string;
+
+	/**
+	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The boundaries of the element, in parent-relative coordinates.
+	 * Setting an element's size or location changes its bounds property, and vice-versa.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * An array of child elements.
+	 */
+	readonly children: Object[];
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
+	 */
+	readonly graphics: ScriptUIGraphics;
+
+	/**
+	 * The help text that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The number of pixels to indent the element during automatic layout.
+	 * Applies for column orientation and left alignment, or row orientation and top alignment.
+	 */
+	indent: number;
+
+	/**
+	 * The layout manager for this container.
+	 * The first time a container object is made visible, ScriptUI invokes this layout manager by calling its layout() function. Default is an instance of the LayoutManager class that is automatically created when the container element is created.
+	 */
+	layout: LayoutManager;
+
+	/**
+	 * The upper left corner of this element relative to its parent.
+	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
+	 */
+	location: Point;
+
+	/**
+	 * The number of pixels between the edges of a container and the outermost child elements.
+	 * You can specify different margins for each edge of the container. The default value is based on the type of container, and is chosen to match the standard Adobe UI guidelines.
+	 */
+	margins: number;
+
+	/**
+	 * The maximum height and width to which the element can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * The minimum height and width to which the element can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The layout orientation of children in a container.
+	 * Interpreted by the layout manager for the container. The default LayoutManager  Object accepts the (case-insensitive) values row, column, or stack.For window and panel, the default is column, and for group the default is row. The allowed values for the container’s alignChildren and its children’s alignment properties depend on the orientation.
+	 */
+	orientation: string;
+
+	/**
+	 * The parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size, used by layout managers to determine the best size for each element.
+	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the control (properties used only when the element is created).
+	 * A Group object has no creation properties.
+	 */
+	properties: Object;
+
+	/**
+	 * The current dimensions of this element.
+	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
+	 */
+	size: Dimension;
+
+	/**
+	 * The number of pixels separating one child element from its adjacent sibling element.
+	 * Because each container holds only a single row or column of children, only a single spacing value is needed for a container. The default value is based on the type of container, and is chosen to match standard Adobe UI guidelines.
+	 */
+	spacing: number;
+
+	/**
+	 * The element type; "group".
+	 */
+	readonly type: string;
+
+	/**
+	 * True if this element is shown, false if it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this element relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Adds a child element to this container.
+	 * Creates and returns a new control or container object and adds it to the children of this group.
+	 * @param type The type of the child element, as specified for the type property. Control types are listed in the JavaScript Tools Guide.
+	 * @param bounds A bounds specification that describes the size and position of the new control or container, relative to its parent. If supplied, this value creates a new Bounds object which is assigned to the new object’s bounds property.
+	 * @param text The text or label, a localizable string. Initial text to be displayed in the control as the title, label, or contents, depending on the control type. If supplied, this value is assigned to the new object’s text property.
+	 * @param properties An object that contains one or more creation properties of the new child (properties used only when the element is created). The creation properties depend on the element type. See properties property of each control type.
+	 */
+	add(type: string, bounds?: Bounds, text?: string, properties?: Object): Object;
+
+	/**
+	 * Registers an event handler for a particular type of event occuring in this element.
+	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): Event;
+
+	/**
+	 * Hides this element.
+	 */
+	hide(): void;
+
+	/**
+	 * An event-handler callback function, called when the group is about to be drawn.
+	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
+	 */
+	onDraw(): void;
+
+	/**
+	 * Removes the specified child control from this group's children array.
+	 * No error results if the child does not exist.
+	 * @param what The child control to remove, specified by 0-based index, text property value, or as a control object.
+	 */
+	remove(what: any): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this element.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Shows this element.
+	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
+	 */
+	show(): void;
+
+}
+
+/**
+ * A container for other types of controls, with an optional frame.
+ * A panel can specify layout options for its child elements. Hiding a panel hides all its children. Making it visible makes visible those children that are not individually hidden.
+ */
+declare class Panel {
+	/**
+	 * Specifies how to align the child elements.
+	 */
+	alignChildren: string;
+
+	/**
+	 * The alignment style for this element. If defined, this value overrides the alignChildren setting for the parent container.
+	 * This can be a single string, which indicates the alignment for the orientation specified in the parent container, or an array of two strings, indicating both the horizontal and vertical alignment (in that order). Allowed values depend on the orientation value of the parent container. They are not case sensitive.
+	 * For orientation=row:top, bottom, fill
+	 * For orientation=column: left, right, fill
+	 * For orientation=stack:top, bottom, left, right, fill
+	 */
+	alignment: string;
+
+	/**
+	 * The boundaries of the element, in parent-relative coordinates.
+	 * Setting an element's size or location changes its bounds property, and vice-versa.
+	 */
+	bounds: Bounds;
+
+	/**
+	 * Reserve space for the specified number of characters; affects calculation of preferredSize .
+	 */
+	characters: number;
+
+	/**
+	 * An array of child elements.
+	 */
+	readonly children: Object[];
+
+	/**
+	 * True if this element is enabled.
+	 * An enabled element can accept input, according to its type. When false, control elements do not accept input, and all types of elements have a dimmed appearance.
+	 */
+	enabled: boolean;
+
+	/**
+	 * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
+	 */
+	readonly graphics: ScriptUIGraphics;
+
+	/**
+	 * The help text that is displayed when the mouse hovers over the element.
+	 */
+	helpTip: string;
+
+	/**
+	 * The number of pixels to indent the element during automatic layout.
+	 * Applies for column orientation and left alignment, or row orientation and top alignment.
+	 */
+	indent: number;
+
+	/**
+	 * The default text justification style for child text elements.
+	 * One of left, center, or right. Justification only works if this value is set on creation of the element.
+	 */
+	justify: string;
+
+	/**
+	 * The layout manager for this container.
+	 * The first time a container object is made visible, ScriptUI invokes this layout manager by calling its layout() function. Default is an instance of the LayoutManager class that is automatically created when the container element is created.
+	 */
+	layout: LayoutManager;
+
+	/**
+	 * The upper left corner of this element's frame relative to its parent.
+	 * The location is defined as [bounds.x, bounds.y]. Setting an element's location changes its bounds property, and vice-versa.
+	 */
+	location: Point;
+
+	/**
+	 * The number of pixels between the edges of a container and the outermost child elements.
+	 * You can specify different margins for each edge of the container. The default value is based on the type of container, and is chosen to match the standard Adobe UI guidelines.
+	 */
+	margins: number;
+
+	/**
+	 * The maximum height and width to which the element can be resized.
+	 */
+	maximumSize: Dimension;
+
+	/**
+	 * The minimum height and width to which the element can be resized.
+	 */
+	minimumSize: Dimension;
+
+	/**
+	 * The layout orientation of children in a container.
+	 * Interpreted by the layout manager for the container. The default LayoutManager  Object accepts the (case-insensitive) values row, column, or stack.For window and panel, the default is column, and for group the default is row. The allowed values for the container’s alignChildren and its children’s alignment properties depend on the orientation.
+	 */
+	orientation: string;
+
+	/**
+	 * The parent element.
+	 */
+	readonly parent: Object;
+
+	/**
+	 * The preferred size, used by layout managers to determine the best size for each element.
+	 * If not explicitly set by a script, value is established by the UI framework in which ScriptUI is employed, and is based on such attributes of the element as its text, font, font size, icon size, and other UI framework-specific attributes.A script can explicitly set this value before the layout manager is invoked in order to establish an element size other than the default.
+	 */
+	preferredSize: Dimension;
+
+	/**
+	 * An object that contains one or more creation properties of the control (properties used only when the element is created).
+	 * Creation properties of a Panel object can include:
+	 * borderStyle: A string that specifies the appearance of the border drawn around the panel. One of black, etched, gray, raised, sunken. Default is etched.
+	 * su1PanelCoordinates: Photoshop only. When true, this panel automatically adjusts the positions of its children for compatability with Photoshop CS. Default is false, meaning that the panel does not adjust the positions of its children, even if the parent window has automatic adjustment enabled.
+	 */
+	properties: Object;
+
+	/**
+	 * The current dimensions of this element.
+	 * Initially undefined, and unless explicitly set by a script, it is defined by a LayoutManager . A script can explicitly set size before the layout manager is invoked to establish an element size other than the preferredSize or the default size, but this is not recommended. Defined as [bounds.width, bounds.height]. Setting an element's size changes its bounds property, and vice-versa.
+	 */
+	size: Dimension;
+
+	/**
+	 * The number of pixels separating one child element from its adjacent sibling element.
+	 * Because each container holds only a single row or column of children, only a single spacing value is needed for a container. The default value is based on the type of container, and is chosen to match standard Adobe UI guidelines.
+	 */
+	spacing: number;
+
+	/**
+	 * The title or label text, a localizable string.
+	 */
+	text: string;
+
+	/**
+	 * The element type; "panel".
+	 */
+	readonly type: string;
+
+	/**
+	 * True if this element is shown, false if it is hidden.
+	 * When a container is hidden, its children are also hidden, but they retain their own visibility values, and are shown or hidden accordingly when the parent is next shown.
+	 */
+	visible: boolean;
+
+	/**
+	 * The window that this element belongs to.
+	 */
+	readonly window: Window;
+
+	/**
+	 * The bounds of this element relative to the top-level parent window.
+	 */
+	readonly windowBounds: Bounds;
+
+	/**
+	 * Adds a child element to this container.
+	 * Creates and returns a new control or container object and adds it to the children of this group.
+	 * @param type The type of the child element, as specified for the type property. Control types are listed in the JavaScript Tools Guide.
+	 * @param bounds A bounds specification that describes the size and position of the new control or container, relative to its parent. If supplied, this value creates a new Bounds object which is assigned to the new object’s bounds property.
+	 * @param text The text or label, a localizable string. Initial text to be displayed in the control as the title, label, or contents, depending on the control type. If supplied, this value is assigned to the new object’s text property.
+	 * @param properties An object that contains one or more creation properties of the new child (properties used only when the element is created). The creation properties depend on the element type. See properties property of each control type.
+	 */
+	add(type: string, bounds?: Bounds, text?: string, properties?: Object): Object;
+
+	/**
+	 * Registers an event handler for a particular type of event occuring in this element.
+	 * @param eventName The name of the event. Event names are listed in the JavaScript Tools Guide.
+	 * @param handler The function that handles the event. This can be the name of a function defined in the extension, or a locally defined handler function to be executed when the event occurs. A handler function takes one argument, the UIEvent object.
+	 * @param capturePhase When true, the handler is called only in the capturing phase of the event propagation. Default is false, meaning that the handler is called in the bubbling phase if this object is an ancestor of the target, or in the at-target phase if this object is itself the target.
+	 */
+	addEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Simulates the occurrence of an event in this target.
+	 * A script can create a UIEvent object for a specific event and pass it to this method to start the event propagation for the event.
+	 */
+	dispatchEvent(): Event;
+
+	/**
+	 * Hides this element.
+	 */
+	hide(): void;
+
+	/**
+	 * An event-handler callback function, called when the panel is about to be drawn.
+	 * Allows the script to modify or control the appearance, using the control’s associated ScriptUIGraphics object. Handler takes one argument, a DrawState object.
+	 */
+	onDraw(): void;
+
+	/**
+	 * Removes the specified child control from this group's children array.
+	 * No error results if the child does not exist.
+	 * @param what The child control to remove, specified by 0-based index, text property value, or as a control object.
+	 */
+	remove(what: any): void;
+
+	/**
+	 * Unregisters an event handler for a particular type of event occuring in this element.
+	 * All arguments must be identical to those that were used to register the event handler.
+	 * @param eventName The name of the event.
+	 * @param handler The function that handles the event.
+	 * @param capturePhase Whether to call the handler only in the capturing phase of the event propagation.
+	 */
+	removeEventListener(eventName: string, handler: Function, capturePhase: boolean): boolean;
+
+	/**
+	 * Shows this element.
+	 * When a window or container is hidden, its children are also hidden, but when it is shown again, the children retain their own visibility states.
+	 */
+	show(): void;
+
+}
+
+
+
+/**
+ * Encapsulates input event information for an event that propagates through a container and control hierarchy.
+ * Implements W3C standard event handling. This object is passed to a function that you register to respond to events of a certain type that occur in a window or control. Use windowObj.addEventListener() or controlObj.addEventListener() to register a handler function.
+ */
+declare class UIEvent {
+	/**
+	 * True if the event is of a type that bubbles.
+	 */
+	readonly bubbles: boolean;
+
+	/**
+	 * True if the default action associated with the event can be canceled with preventDefault().
+	 */
+	readonly cancelable: boolean;
+
+	/**
+	 * True if this event can be captured.
+	 */
+	readonly captures: boolean;
+
+	/**
+	 * The event target object which is currently handling the event. During capturing and bubbling, this is different from the property target.
+	 */
+	readonly currentTarget: boolean;
+
+	/**
+	 * The click count for a mouse-click event.
+	 */
+	readonly detail: any;
+
+	/**
+	 * The current phase of event propagation; one of none, target, capture, bubble.
+	 */
+	readonly eventPhase: string;
+
+	/**
+	 * The event target object for this event.
+	 */
+	readonly target: Object;
+
+	/**
+	 * The date and time at which the event occurred.
+	 */
+	readonly timeStamp: Date;
+
+	/**
+	 * The name of the event that thisobject represents.
+	 * Event types are listed in the JavaScript Tools Guide.
+	 */
+	readonly type: string;
+
+	/**
+	 * The ScriptUI element that this event relates to.
+	 */
+	readonly view: any;
+
+	/**
+	 * Creates an event.
+	 * The UIEvent object is normally created by ScriptUI and passed to your event handler. However, you can simulate a user action by constructing an event object and sending it to a target object’s dispatchEvent() function.
+	 * @param type The event type. See UIEvent.type property.
+	 * @param captures Set to true if this event can be captured.
+	 * @param bubbles Set to true if the event bubbles.
+	 * @param view The ScriptUI element that this event relates to.
+	 * @param detail The click count for a mouse-click event.
+	 */
+	constructor(type: string, captures: boolean, bubbles: boolean, view?: Object, detail?: number);
+
+	/**
+	 * Initializes a UI event as a core W3C event.
+	 * @param type The event type.
+	 * @param captures Set to true if this event can be captured.
+	 * @param bubbles Set to true if the event bubbles.
+	 * @param cancelable Set to true if the default action is cancelable.
+	 */
+	initEvent(type: string, captures: boolean, bubbles: boolean, cancelable: boolean): void;
+
+	/**
+	 * Initializes an event.
+	 * @param type The event type.
+	 * @param captures Set to true if this event can be captured.
+	 * @param bubbles Set to true if the event bubbles.
+	 * @param view The ScriptUI element that this event relates to.
+	 * @param detail The click count for a mouse-click event.
+	 */
+	initUIEvent(type: string, captures: boolean, bubbles: boolean, view?: Object, detail?: number): void;
+
+	/**
+	 * Prevents the default action associated with this event from being called.
+	 */
+	preventDefault(): void;
+
+	/**
+	 * Stops the propagation of this event.
+	 */
+	stopPropagation(): void;
+
+}


### PR DESCRIPTION
I moved the ScriptUI types from aftereffects.d.ts into the ScriptUI/index.d.ts.
They seem to be better in a lot of ways, however, I still have to check if we did not break anything so I put the things I replaced in "retired.d.ts" for (manual) checking.

The current ScriptUI still implements Bounds, Point and probably others as an object whereas these are actually arrays in (just weirdly implemented / documented in ExtendScript)