### PR TITLE
add "FolderItem" as possible type returned by app.project.openFile.

### DIFF
--- a/AfterEffects/2018/index.d.ts
+++ b/AfterEffects/2018/index.d.ts
@@ -1628,7 +1628,7 @@ declare class Project {
 	importPlaceholder(name: string, width: number, height: number, frameRate: number, duration: number): PlaceholderItem;
 
 	/** Imports a file into the project. */
-	importFile(importOptions: ImportOptions): FootageItem;
+	importFile(importOptions: ImportOptions): FootageItem | FolderItem;
 
 	/** Displays an Import File dialog box. */
 	importFileWithDialog(): Item[] | null;


### PR DESCRIPTION
It isn't documented, but app.project.openFile can return a FolderItem if you are importing an AE project.  Here's an example showing this behavior.

```javascript
var io = new ImportOptions(new File("/path/to/project.aep"));
io.importAs =  ImportAsType.PROJECT;
var item = app.project.importFile(io);
```
In this case, `item instanceof FolderItem` returns `true`.
