### PR TITLE
Update AE & scriptUI defs

### DIFF
--- a/AfterEffects/2018/index.d.ts
+++ b/AfterEffects/2018/index.d.ts
@@ -1,9 +1,10 @@
 /// <reference path="../../shared/global.d.ts" />
 /// <reference path="../../shared/ScriptUI.d.ts" />
 
-declare class Global {
-  app: Application
-}
+/**
+ * The global System object.
+ */
+declare var system: System
 
 /** CONSTANTS */
 declare const enum AppVersion {
@@ -20,7 +21,8 @@ declare const enum AppVersion {
   CC2015_3 = 13.8,
   CC2017 = 14.0,
   CC2018 = 15.0,
-  CC2019 = 16.0
+  CC2019 = 16.0,
+  CC2020 = 17.0,
 }
 
 declare const enum CommandID {
@@ -1009,7 +1011,7 @@ declare class AVLayer extends Layer {
   compPointToSource(point: [number, number]): [number, number]
 
   /** Shortcuts */
-  readonly timeRemap: Property
+  readonly timeRemap: Property<number>
   readonly mask: MaskPropertyGroup
   readonly effect: PropertyGroup
   readonly layerStyle: _LayerStyles
@@ -1093,13 +1095,13 @@ declare class CompItem extends AVItem {
   readonly layers: LayerCollection
 
   /** CC 2017(14.0)- The markers of the composition. */
-  readonly markerProperty: Property
+  readonly markerProperty: Property<MarkerValue>
 
   /** The selected layers of the composition. */
   readonly selectedLayers: Layer[]
 
   /** The selected properties of the composition. */
-  readonly selectedProperties: PropertyBase[]
+  readonly selectedProperties: Property<any>[] | PropertyGroup[] | MaskPropertyGroup[]
 
   /** The rendering plug-in module to be used to render this composition. */
   renderer: string
@@ -1314,8 +1316,8 @@ declare class KeyframeEase {
 
 /** The Layer object provides access to layers within compositions. It can be accessed from an item’s layer collection either by index number or by a name string. */
 declare interface Layer {
-  (index: number): PropertyBase
-  (name: string): PropertyBase
+  (index: number): Property<any> | PropertyGroup
+  (name: string): Property<any> | PropertyGroup
 }
 
 declare class Layer {
@@ -1365,7 +1367,7 @@ declare class Layer {
   readonly nullLayer: boolean
 
   /** All selected AE properties in the layer. */
-  readonly selectedProperties: PropertyBase[]
+  readonly selectedProperties: (Property<any> | PropertyGroup | MaskPropertyGroup)[]
 
   /** A descriptive comment for the layer. */
   comment: string
@@ -1419,28 +1421,28 @@ declare class Layer {
   selected: boolean
   readonly numProperties: number
 
-  propertyGroup(countUp?: number): PropertyGroup
-  property(index: number): PropertyBase
-  property(name: string): PropertyBase
+  propertyGroup(countUp?: number): PropertyGroup | Layer
+  property(index: number): Property<any> | PropertyGroup | MaskPropertyGroup
+  property(name: string): Property<any> | PropertyGroup | MaskPropertyGroup
 
   /** Shortcuts */
-  readonly marker: Property
+  readonly marker: Property<MarkerValue>
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: Property
-  readonly position: Property
-  readonly xPosition: Property
-  readonly yPosition: Property
-  readonly zPosition: Property
-  readonly scale: Property
-  readonly orientation: Property
-  readonly rotation: Property
-  readonly xRotation: Property
-  readonly yRotation: Property
-  readonly zRotation: Property
-  readonly opacity: Property
-  readonly pointOfInterest: Property
+  readonly anchorPoint: Property<number>
+  readonly position: Property<[number, number] | [number, number, number]>
+  readonly xPosition: Property<number>
+  readonly yPosition: Property<number>
+  readonly zPosition: Property<number>
+  readonly scale: Property<[number, number] | [number, number, number]>
+  readonly orientation: Property<[number, number, number]>
+  readonly rotation: Property<number>
+  readonly xRotation: Property<number>
+  readonly yRotation: Property<number>
+  readonly zRotation: Property<number>
+  readonly opacity: Property<number>
+  readonly pointOfInterest: Property<[number, number, number]>
 }
 
 /** The LayerCollection object represents a set of layers. The LayerCollection belonging to a CompItem object contains all the layer objects for layers in the composition. The methods of the collection object allow you to manipulate the layer list. */
@@ -1534,11 +1536,6 @@ declare class MarkerValue {
   setParameters(keyValuePairs: object): void
 }
 
-declare interface MaskPropertyGroup {
-  (index: number): MaskPropertyGroup
-  (name: string): MaskPropertyGroup
-}
-
 /** The MaskPropertyGroup object encapsulates mask attributes in a layer. */
 declare class MaskPropertyGroup extends PropertyGroup {
   /** The mask mode. */
@@ -1563,7 +1560,17 @@ declare class MaskPropertyGroup extends PropertyGroup {
   maskFeatherFalloff: MaskFeatherFalloff
 
   /** The shape of the mask */
-  maskShape: Property
+  maskShape: Shape
+  maskPath: Shape
+
+  /** The mask feather amount */
+  maskFeather: Property<[number, number]>
+
+  /** The mask opacity */
+  maskOpacity: Property<number>
+
+  /** The mask expansion amount */
+  maskExpansion: Property<number>
 }
 
 /** The OMCollection contains all of the output modules in a render queue. The collection provides access to the OutputModule objects, but does not provide any additional functionality. The first OutputModule object in the collection is at index position 1. */
@@ -1741,10 +1748,10 @@ declare class Project {
 
   /** Creates a new team project. */
   newTeamProject(
-    teamProjectName: string, 
+    teamProjectName: string,
     description: string
   ): boolean
-  
+
   /** Opens a team project. */
   openTeamProject(
     teamProjectName: string
@@ -1760,7 +1767,7 @@ declare class Project {
 
   /** Closes a currently open team project. */
   closeTeamProject(): boolean
-  
+
   /** Converts a team project to an After Effects project on a local disk. */
   convertTeamProjectToProject(
     project_file: File
@@ -1796,7 +1803,6 @@ declare class Project {
   resolveConflict(
     ResolveType: ResolveType
   ): boolean
-
 }
 
 declare type PropertyValue =
@@ -1811,7 +1817,7 @@ declare type PropertyValue =
   | TextDocument
 
 /** The Property object contains value, keyframe, and expression information about a particular AE property of a layer. */
-declare class Property extends PropertyBase {
+declare class Property<PropertyValue> extends PropertyBase {
   /** Type of value stored in this property. */
   readonly propertyValueType: PropertyValueType
 
@@ -1876,7 +1882,7 @@ declare class Property extends PropertyBase {
   readonly separationDimension: number
 
   /** The original multidimensional property for this separated follower. */
-  readonly separationLeader: Property
+  readonly separationLeader: Property<PropertyValue>
 
   /** Gets the value of the property evaluated at given time. */
   valueAtTime(time: number, preExpression: boolean): PropertyValue
@@ -2008,13 +2014,13 @@ declare class Property extends PropertyBase {
   keySelected(keyIndex: number): boolean
 
   /** For a separated, multidimensional property, retrieves a specific follower property. */
-  getSeparationFollower(dim: number): Property
+  getSeparationFollower?(dim: number): Property<number>
 }
 
 /** Properties are accessed by name through layers, using various kinds of expression syntax, as controlled by application preferences. */
 declare interface PropertyBase {
-  (index: number): PropertyBase
-  (name: string): PropertyBase
+  (index: number): Property<any> | PropertyGroup | MaskPropertyGroup
+  (name: string): Property<any> | PropertyGroup | MaskPropertyGroup
 }
 
 declare class PropertyBase {
@@ -2061,7 +2067,7 @@ declare class PropertyBase {
   selected: boolean
 
   /** Gets the parent group for this property. */
-  propertyGroup(countUp?: number): PropertyGroup
+  propertyGroup(countUp?: number): PropertyGroup | Layer
 
   /** Removes this from the project. */
   remove(): void
@@ -2070,11 +2076,11 @@ declare class PropertyBase {
   moveTo(newIndex: number): void
 
   /** Duplicates this property object. */
-  duplicate(): PropertyBase
+  duplicate(): Property<any> | PropertyGroup | MaskPropertyGroup
 
   /** Gets a member property or group. Strictly, this should be PropertyGroup method. */
-  property(index: number): PropertyBase
-  property(name: string): PropertyBase
+  property(index: number): Property<any> | PropertyGroup | MaskPropertyGroup
+  property(name: string): Property<any> | PropertyGroup | MaskPropertyGroup
 }
 
 /** The PropertyGroup object represents a group of properties. It can contain Property objects and other PropertyGroup objects. Property groups can be nested to provide a parent-child hierarchy, with a Layer object at the top (root) down to a single Property object, such as the mask feather of the third mask. To traverse the group hierarchy, use PropertyBase methods and attributes. */
@@ -2090,7 +2096,7 @@ declare class PropertyGroup extends PropertyBase {
   canAddProperty(name: string): boolean
 
   /** Adds a property to the group. */
-  addProperty(name: string): PropertyBase
+  addProperty(name: string): Property<any> | PropertyGroup | MaskPropertyGroup
 }
 
 /** The RenderQueue object represents the render automation process, the data and functionality that is available through the Render Queue panel of a particular After Effects project. Attributes provide access to items in the render queue and their render status. Methods can start, pause, and stop the rendering process. */
@@ -2415,7 +2421,9 @@ declare class TextDocument {
 declare class TextLayer extends AVLayer {
   readonly source: null
 
+  /** Shortcuts */
   readonly text: _TextProperties
+  readonly sourceText: Property<TextDocument>
 }
 
 /** The Viewer object represents a Composition, Layer, or Footage panel. */
@@ -2456,48 +2464,48 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare class _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: Property
-  readonly position: Property
-  readonly xPosition: Property
-  readonly yPosition: Property
-  readonly zPosition: Property
-  readonly scale: Property
-  readonly orientation: Property
-  readonly rotation: Property
-  readonly xRotation: Property
-  readonly yRotation: Property
-  readonly zRotation: Property
-  readonly opacity: Property
-  readonly pointOfInterest: Property
+  readonly anchorPoint: Property<number>
+  readonly position: Property<[number, number] | [number, number, number]>
+  readonly xPosition: Property<number>
+  readonly yPosition: Property<number>
+  readonly zPosition: Property<number>
+  readonly scale: Property<[number, number] | [number, number, number]>
+  readonly orientation: Property<[number, number, number]>
+  readonly rotation: Property<number>
+  readonly xRotation: Property<number>
+  readonly yRotation: Property<number>
+  readonly zRotation: Property<number>
+  readonly opacity: Property<number>
+  readonly pointOfInterest: Property<[number, number, number]>
 }
 
 declare class _LightOptionsGroup extends PropertyGroup {
-  readonly intensity: Property
-  readonly color: Property
-  readonly coneAngle: Property
-  readonly coneFeather: Property
-  readonly falloff: Property
-  readonly radius: Property
-  readonly falloffDistance: Property
-  readonly castsShadows: Property
-  readonly shadowDarkness: Property
-  readonly shadowDiffusion: Property
+  readonly intensity: Property<number>
+  readonly color: Property<[number, number, number, number]>
+  readonly coneAngle: Property<number>
+  readonly coneFeather: Property<number>
+  readonly falloff: Property<number>
+  readonly radius: Property<number>
+  readonly falloffDistance: Property<number>
+  readonly castsShadows: Property<boolean>
+  readonly shadowDarkness: Property<number>
+  readonly shadowDiffusion: Property<number>
 }
 
 declare class _CameraOptionsGroup extends PropertyGroup {
-  readonly zoom: Property
-  readonly depthOfField: Property
-  readonly focusDistance: Property
-  readonly aperture: Property
-  readonly blurLevel: Property
-  readonly irisShape: Property
-  readonly irisRotation: Property
-  readonly irisRoundness: Property
-  readonly irisAspectRatio: Property
-  readonly irisDiffractionFringe: Property
-  readonly highlightGain: Property
-  readonly highlightThreshold: Property
-  readonly highlightSaturation: Property
+  readonly zoom: Property<number>
+  readonly depthOfField: Property<boolean>
+  readonly focusDistance: Property<number>
+  readonly aperture: Property<number>
+  readonly blurLevel: Property<number>
+  readonly irisShape: Property<number>
+  readonly irisRotation: Property<number>
+  readonly irisRoundness: Property<number>
+  readonly irisAspectRatio: Property<number>
+  readonly irisDiffractionFringe: Property<number>
+  readonly highlightGain: Property<number>
+  readonly highlightThreshold: Property<number>
+  readonly highlightSaturation: Property<number>
 }
 
 declare class _LayerStyles extends PropertyGroup {
@@ -2514,177 +2522,177 @@ declare class _LayerStyles extends PropertyGroup {
 }
 
 declare class _BlendOptionsGroup extends PropertyGroup {
-  readonly globalLightAngle: Property
-  readonly globalLightAltitude: Property
+  readonly globalLightAngle: Property<number>
+  readonly globalLightAltitude: Property<number>
   readonly advancedBlending: _AdvBlendGroup
 }
 
 declare class _AdvBlendGroup extends PropertyGroup {
-  readonly fillOpacity: Property
-  readonly red: Property
-  readonly green: Property
-  readonly blue: Property
-  readonly blendInteriorStylesAsGroup: Property
-  readonly useBlendRangesFromSource: Property
+  readonly fillOpacity: Property<number>
+  readonly red: Property<boolean>
+  readonly green: Property<boolean>
+  readonly blue: Property<boolean>
+  readonly blendInteriorStylesAsGroup: Property<boolean>
+  readonly useBlendRangesFromSource: Property<boolean>
 }
 
 declare class _DropShadow extends PropertyGroup {
-  readonly blendMode: Property
-  readonly color: Property
-  readonly opacity: Property
-  readonly useGlobalLight: Property
-  readonly angle: Property
-  readonly distance: Property
-  readonly spread: Property
-  readonly size: Property
-  readonly noise: Property
-  readonly layerKnocksOutDropShadow: Property
+  readonly blendMode: Property<number>
+  readonly color: Property<[number, number, number, number]>
+  readonly opacity: Property<number>
+  readonly useGlobalLight: Property<boolean>
+  readonly angle: Property<number>
+  readonly distance: Property<number>
+  readonly spread: Property<number>
+  readonly size: Property<number>
+  readonly noise: Property<number>
+  readonly layerKnocksOutDropShadow: Property<boolean>
 }
 
 declare class _InnerShadow extends PropertyGroup {
-  readonly blendMode: Property
-  readonly color: Property
-  readonly opacity: Property
-  readonly useGlobalLight: Property
-  readonly angle: Property
-  readonly distance: Property
-  readonly choke: Property
-  readonly size: Property
-  readonly noise: Property
+  readonly blendMode: Property<number>
+  readonly color: Property<[number, number, number, number]>
+  readonly opacity: Property<number>
+  readonly useGlobalLight: Property<boolean>
+  readonly angle: Property<number>
+  readonly distance: Property<number>
+  readonly choke: Property<number>
+  readonly size: Property<boolean>
+  readonly noise: Property<number>
 }
 
 declare class _OuterGlow extends PropertyGroup {
-  readonly blendMode: Property
-  readonly opacity: Property
-  readonly noise: Property
-  readonly colorType: Property
-  readonly color: Property
-  readonly colors: Property
-  readonly gradientSmoothness: Property
-  readonly technique: Property
-  readonly spread: Property
-  readonly size: Property
-  readonly range: Property
-  readonly jitter: Property
+  readonly blendMode: Property<number>
+  readonly opacity: Property<number>
+  readonly noise: Property<number>
+  readonly colorType: Property<number>
+  readonly color: Property<[number, number, number, number]>
+  readonly colors: Property<void>
+  readonly gradientSmoothness: Property<number>
+  readonly technique: Property<number>
+  readonly spread: Property<number>
+  readonly size: Property<number>
+  readonly range: Property<number>
+  readonly jitter: Property<number>
 }
 
 declare class _InnerGlow extends PropertyGroup {
-  readonly blendMode: Property
-  readonly opacity: Property
-  readonly noise: Property
-  readonly colorType: Property
-  readonly color: Property
-  readonly colors: Property
-  readonly gradientSmoothness: Property
-  readonly technique: Property
-  readonly source: Property
-  readonly choke: Property
-  readonly size: Property
-  readonly range: Property
-  readonly jitter: Property
+  readonly blendMode: Property<number>
+  readonly opacity: Property<number>
+  readonly noise: Property<number>
+  readonly colorType: Property<number>
+  readonly color: Property<[number, number, number, number]>
+  readonly colors: Property<void>
+  readonly gradientSmoothness: Property<number>
+  readonly technique: Property<number>
+  readonly source: Property<number>
+  readonly choke: Property<number>
+  readonly size: Property<number>
+  readonly range: Property<number>
+  readonly jitter: Property<number>
 }
 
 declare class _BevelAndEmboss extends PropertyGroup {
-  readonly style: Property
-  readonly technique: Property
-  readonly depth: Property
-  readonly direction: Property
-  readonly size: Property
-  readonly soften: Property
-  readonly useGlobalLight: Property
-  readonly angle: Property
-  readonly altitude: Property
-  readonly highlightMode: Property
-  readonly highlightColor: Property
-  readonly highlightOpacity: Property
-  readonly shadowMode: Property
-  readonly shadowColor: Property
-  readonly shadowOpacity: Property
+  readonly style: Property<number>
+  readonly technique: Property<number>
+  readonly depth: Property<number>
+  readonly direction: Property<number>
+  readonly size: Property<number>
+  readonly soften: Property<number>
+  readonly useGlobalLight: Property<boolean>
+  readonly angle: Property<number>
+  readonly altitude: Property<number>
+  readonly highlightMode: Property<number>
+  readonly highlightColor: Property<[number, number, number, number]>
+  readonly highlightOpacity: Property<number>
+  readonly shadowMode: Property<number>
+  readonly shadowColor: Property<[number, number, number, number]>
+  readonly shadowOpacity: Property<number>
 }
 
 declare class _Satin extends PropertyGroup {
-  readonly blendMode: Property
-  readonly color: Property
-  readonly opacity: Property
-  readonly angle: Property
-  readonly distance: Property
-  readonly size: Property
-  readonly invert: Property
+  readonly blendMode: Property<number>
+  readonly color: Property<[number, number, number, number]>
+  readonly opacity: Property<number>
+  readonly angle: Property<number>
+  readonly distance: Property<number>
+  readonly size: Property<number>
+  readonly invert: Property<boolean>
 }
 
 declare class _ColorOverlay extends PropertyGroup {
-  readonly blendMode: Property
-  readonly color: Property
-  readonly opacity: Property
+  readonly blendMode: Property<number>
+  readonly color: Property<[number, number, number, number]>
+  readonly opacity: Property<number>
 }
 
 declare class _GradientOverlay extends PropertyGroup {
-  readonly blendMode: Property
-  readonly opacity: Property
-  readonly colors: Property
-  readonly gradientSmoothness: Property
-  readonly angle: Property
-  readonly style: Property
-  readonly reverse: Property
-  readonly alignWithLayer: Property
-  readonly scale: Property
-  readonly offset: Property
+  readonly blendMode: Property<number>
+  readonly opacity: Property<number>
+  readonly colors: Property<void>
+  readonly gradientSmoothness: Property<number>
+  readonly angle: Property<number>
+  readonly style: Property<number>
+  readonly reverse: Property<boolean>
+  readonly alignWithLayer: Property<boolean>
+  readonly scale: Property<number>
+  readonly offset: Property<[number, number]>
 }
 
 declare class _Stroke extends PropertyGroup {
-  readonly color: Property
-  readonly blendMode: Property
-  readonly size: Property
-  readonly opacity: Property
-  readonly position: Property
+  readonly color: Property<[number, number, number, number]>
+  readonly blendMode: Property<number>
+  readonly size: Property<number>
+  readonly opacity: Property<number>
+  readonly position: Property<number>
 }
 
 declare class _GeometryOptionsGroup extends PropertyGroup {
-  readonly curvature: Property
-  readonly segments: Property
+  readonly curvature: Property<number>
+  readonly segments: Property<number>
 
-  readonly bevelStyle: Property
-  readonly bevelDepth: Property
-  readonly holeBevelDepth: Property
-  readonly extrusionDepth: Property
+  readonly bevelStyle: Property<number>
+  readonly bevelDepth: Property<number>
+  readonly holeBevelDepth: Property<number>
+  readonly extrusionDepth: Property<number>
 }
 
 declare class _MaterialOptionsGroup extends PropertyGroup {
-  readonly castsShadows: Property
-  readonly lightTransmission: Property
-  readonly acceptsShadows: Property
-  readonly acceptsLights: Property
-  readonly appearsInReflections: Property
-  readonly ambient: Property
-  readonly diffuse: Property
-  readonly specularIntensity: Property
-  readonly specularShininess: Property
-  readonly metal: Property
-  readonly reflectionIntensity: Property
-  readonly reflectionSharpness: Property
-  readonly reflectionRolloff: Property
-  readonly transparency: Property
-  readonly transparencyRolloff: Property
-  readonly indexOfRefraction: Property
+  readonly castsShadows: Property<boolean>
+  readonly lightTransmission: Property<number>
+  readonly acceptsShadows: Property<boolean>
+  readonly acceptsLights: Property<boolean>
+  readonly appearsInReflections: Property<boolean>
+  readonly ambient: Property<number>
+  readonly diffuse: Property<number>
+  readonly specularIntensity: Property<number>
+  readonly specularShininess: Property<number>
+  readonly metal: Property<number>
+  readonly reflectionIntensity: Property<number>
+  readonly reflectionSharpness: Property<number>
+  readonly reflectionRolloff: Property<number>
+  readonly transparency: Property<number>
+  readonly transparencyRolloff: Property<number>
+  readonly indexOfRefraction: Property<number>
 }
 
 declare class _AudioGroup extends PropertyGroup {
-  readonly audioLevels: Property
+  readonly audioLevels: Property<[number, number]>
 }
 
 declare class _TextProperties extends PropertyGroup {
-  readonly sourceText: Property
+  readonly sourceText: Property<TextDocument>
   readonly pathOption: _TextPathOptions
   readonly moreOption: _TextMoreOptions
 }
 
 declare class _TextPathOptions extends PropertyGroup {
-  readonly path: Property
+  readonly path: Property<number>
 }
 
 declare class _TextMoreOptions extends PropertyGroup {
-  readonly anchorPointGrouping: Property
-  readonly groupingAlignment: Property
-  readonly fillANdStroke: Property
-  readonly interCharacterBlending: Property
+  readonly anchorPointGrouping: Property<number>
+  readonly groupingAlignment: Property<[number, number]>
+  readonly fillANdStroke: Property<number>
+  readonly interCharacterBlending: Property<number>
 }

--- a/shared/ScriptUI.d.ts
+++ b/shared/ScriptUI.d.ts
@@ -1,5 +1,33 @@
 /// <reference path="JavaScript.d.ts" />
 
+declare enum Alignment {
+  TOP,
+  BOTTOM,
+  LEFT,
+  RIGHT,
+  FILL,
+  CENTER
+}
+
+declare enum FontStyle {
+  REGULAR,
+  BOLD,
+  ITALIC,
+  BOLDITALIC
+}
+
+declare const enum BrushType {
+  SOLID_COLOR = 0,
+  THEME_COLOR = 1
+}
+
+declare const enum PenType {
+  SOLID_COLOR = 0,
+  THEME_COLOR = 1
+}
+
+declare type _Container = Panel | Window | Group;
+
 /**
  * A global class containing central information about ScriptUI. Not instantiable.
  */
@@ -8,13 +36,13 @@ declare class ScriptUI {
    * Collects the enumerated values that can be used in the alignment and alignChildren properties of controls and containers.
    * Predefined alignment values are: TOP, BOTTOM, LEFT, RIGHT, FILL, CENTER
    */
-  static readonly Alignment: string
+  static readonly Alignment: Alignment
 
   /**
    * Collects the enumerated values that can be used as the style argument to the ScriptUI.newFont() method.
    * Predefined styles are REGULAR, BOLD, ITALIC, BOLDITALIC.
    */
-  static readonly FontStyle: object
+  static readonly FontStyle: FontStyle
 
   /**
    * The font constants defined by the host application.
@@ -118,7 +146,7 @@ declare class Window extends _Control {
    * The collection of UI elements that have been added to this container.
    * An array indexed by number or by a string containing an element's name. The length property of this array is the number of child elements for container elements, and is zero for controls.
    */
-  readonly children: object[]
+  readonly children: _Control[]
 
   /**
    * For windows of type dialog, the UI element to notify when the user presses a Enter key.
@@ -359,8 +387,10 @@ declare class LayoutManager {
    * Invokes the automatic layout behavior for the managed container.
    * Adjusts sizes and positions of the child elements of this window or container according to the placement and alignment property values in the parent and children.
    * Invoked automatically the first time the window is displayed. Thereafter, the script must invoke it explicitly to change the layout in case of changes in the size or position of the parent or children.
+   *
+   * @param recalculate Optional. When true, forces the layout manager to recalculate the container size for this and any child containers. Default is false.
    */
-  layout(): void
+  layout(recalculate?: boolean): void
 
   /**
    * Performs a layout after a Window is resized, based on the new size.
@@ -395,7 +425,7 @@ declare class ScriptUIPen {
    * The pen type, solid or theme.
    * One of these constants: ScriptUIGraphics.PenType.SOLID_COLOR or ScriptUIGraphics.PenType.THEME_COLOR
    */
-  readonly type: string
+  readonly type: typeof PenType
 }
 
 /**
@@ -419,7 +449,7 @@ declare class ScriptUIBrush {
    * The brush type, solid or theme.
    * One of these constants: ScriptUIGraphics.BrushType.SOLID_COLOR or ScriptUIGraphics.BrushType.THEME_COLOR
    */
-  readonly type: number
+  readonly type: typeof BrushType
 }
 
 /**
@@ -433,17 +463,18 @@ declare class ScriptUIPath {}
  * Allows a script to customize aspects of the element’s appearance, such as the color and font. Use an onDraw callback function to set these properties or call the functions.All measurements are in pixels.
  */
 declare class ScriptUIGraphics {
+
   /**
    * Contains the enumerated constants for the type argument of newBrush().
    * Type constants are: SOLID_COLOR, THEME_COLOR.
    */
-  static readonly BrushType: object
+  readonly BrushType: typeof BrushType
 
   /**
    * Contains the enumerated constants for the type argument of newPen().
    * Type constants are: SOLID_COLOR, THEME_COLOR.
    */
-  static readonly PenType: object
+  readonly PenType: typeof PenType
 
   /**
    * The background color for containers; for non-containers, the parent background color.
@@ -572,7 +603,7 @@ declare class ScriptUIGraphics {
    * @param type The brush type, solid or theme. One of the constants ScriptUIGraphics.BrushType.SOLID_COLOR or ScriptUIGraphics.BrushType.THEME_COLOR.
    * @param color The brush color. If type is SOLID_COLOR, the color expressed as an array of three or four values, in the form [R, B, G, A] specifying the red, green, and blue values of the color and, optionally, the opacity (alpha channel). All values are numbers in the range [0.0..1.0]. An opacity of 0 is fully transparent, and an opacity of 1 is fully opaque. If the type is THEME_COLOR, the name string of the theme. Theme colors are defined by the host application.
    */
-  newBrush(type: number, color: number[]): ScriptUIBrush
+  newBrush(type: BrushType, color: number[]): ScriptUIBrush
 
   /**
    * Creates a new, empty path object.
@@ -586,7 +617,7 @@ declare class ScriptUIGraphics {
    * @param color The pen color. If type is SOLID_COLOR, the color expressed as an array of three or four values, in the form [R, B, G, A] specifying the red, green, and blue values of the color and, optionally, the opacity (alpha channel). All values are numbers in the range [0.0..1.0]. An opacity of 0 is fully transparent, and an opacity of 1 is fully opaque. If the type is THEME_COLOR, the name string of the theme. Theme colors are defined by the host application.
    * @param width The width of the pen line in pixels. The line is centered around the current point. For example, if the value is 2, drawing a line from (0, 10) to (5, 10) paints the two rows of pixels directly above and below y-position 10.
    */
-  newPen(type: number, color: number[], width: number): ScriptUIPen
+  newPen(type: PenType, color: number[], width: number): ScriptUIPen
 
   /**
    * Defines a rectangular path in the currentPath object.
@@ -695,7 +726,7 @@ declare class ScriptUIFont {
   /**
    * The font style. One of the constants in ScriptUIGraphics.FontStyle.
    */
-  readonly style: object
+  readonly style: FontStyle
 
   /**
    * The name of a substitution font, a fallback font to substitute for this font if the requested font family or style is not available.
@@ -1283,7 +1314,7 @@ declare class ListItem {
   /**
    * The parent element, a list control.
    */
-  readonly parent: object
+  readonly parent: _Control
 
   /**
    * The selection state of this item.
@@ -1883,7 +1914,7 @@ declare class Group extends _Control {
   /**
    * An array of child elements.
    */
-  readonly children: object[]
+  readonly children: _Control[]
 
   /**
    * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
@@ -1956,7 +1987,7 @@ declare class Panel extends _Control {
   /**
    * An array of child elements.
    */
-  readonly children: object[]
+  readonly children: _Control[]
 
   /**
    * The graphics object that can be used to customize the element's appearance, in response to the onDraw() event.
@@ -2175,7 +2206,7 @@ declare class UIEvent {
   /**
    * The current phase of event propagation; one of none, target, capture, bubble.
    */
-  readonly eventPhase: string
+  readonly eventPhase: number
 
   /**
    * The event target object for this event.
@@ -2293,7 +2324,7 @@ declare class Event {
   /**
    * The current phase of event propagation; one of none, target, capture, bubble.
    */
-  readonly eventPhase: string
+  readonly eventPhase: number
 
   /**
    * The event target object for this event.
@@ -2437,7 +2468,7 @@ declare class _Control {
   /**
    * The parent element.
    */
-  readonly parent: object
+  readonly parent: _Container
 
   /**
    * The preferred size, used by layout managers to determine the best size for each element.


### PR DESCRIPTION
*AE*

Using this with AE sucks, as it doesn't (didn't) properly handle `x.property()` return types; it was always returning as `PropertyBase`, when it should be returning as `Property` or a `PropertyGroup`  variant.

In addition, more precise property types would be SO much more useful than everything returning as an arbitrary `value`, so added that too.

*SUI*

- add missing enums
- add missing optional param for win.layout()
- add more precise children/parent prop types
- swap incorrect 'string' type with 'number' for other enums / enum-style values
- fix Pen and Brush types