### PR TITLE
Add package.json's for yarn > v1 support

### DIFF
--- a/AfterEffects/10.5/package.json
+++ b/AfterEffects/10.5/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/10.5",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/11.0/package.json
+++ b/AfterEffects/11.0/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/11.0",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/12.0/package.json
+++ b/AfterEffects/12.0/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/12.0",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/13.0/package.json
+++ b/AfterEffects/13.0/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/13.0",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/13.1/package.json
+++ b/AfterEffects/13.1/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/13.1",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/13.2/package.json
+++ b/AfterEffects/13.2/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/13.2",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/13.6/package.json
+++ b/AfterEffects/13.6/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/13.6",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/13.8/package.json
+++ b/AfterEffects/13.8/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/13.8",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/14.0/package.json
+++ b/AfterEffects/14.0/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/14.0",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/14.2/package.json
+++ b/AfterEffects/14.2/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/14.2",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/15.0/package.json
+++ b/AfterEffects/15.0/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/15.0",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/16.0/package.json
+++ b/AfterEffects/16.0/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/16.0",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/16.1/package.json
+++ b/AfterEffects/16.1/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/16.1",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/17.0/package.json
+++ b/AfterEffects/17.0/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/17.0",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/17.1/package.json
+++ b/AfterEffects/17.1/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/17.1",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/18.0/package.json
+++ b/AfterEffects/18.0/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/18.0",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/8.0/package.json
+++ b/AfterEffects/8.0/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/8.0",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/AfterEffects/9.0/package.json
+++ b/AfterEffects/9.0/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/AfterEffects/9.0",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/Animate/2013/package.json
+++ b/Animate/2013/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/Animate/2013",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/Audition/2015.2/package.json
+++ b/Audition/2015.2/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/Audition/2015.2",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/Audition/2017/package.json
+++ b/Audition/2017/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/Audition/2017",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/Audition/2018/package.json
+++ b/Audition/2018/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/Audition/2018",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/Illustrator/2015.3/package.json
+++ b/Illustrator/2015.3/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/Illustrator/2015.3",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/InDesign/2015.3/package.json
+++ b/InDesign/2015.3/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/InDesign/2015.3",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/InDesign/2018/package.json
+++ b/InDesign/2018/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/InDesign/2018",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/Photoshop/2015.5/package.json
+++ b/Photoshop/2015.5/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/Photoshop/2015.5",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/Premiere/2018/package.json
+++ b/Premiere/2018/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "types-for-adobe/Premiere/2018",
+	"version": "1.0.0",
+	"main": "index.d.ts",
+	"types": "index.d.ts"
+}

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="./PlugPlugExternalObject.d.ts" />

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "types-for-adobe/shared",
+  "version": "1.0.0",
+  "main": "index.d.ts",
+  "types": "index.d.ts"
+}


### PR DESCRIPTION
Basically, references don't seem to work when using yarn berry (might also not work with other PnP implementations)

But using the "types" field in the package.json makes things work, so this PR includes a package.json in all folder so they can be included without references (see the tsconfig.json in the example below)

```
# create new folder
mkdir my-script
cd my-script

# install types-for-adobe
npm install -g yarn
yarn init -y
yarn set version berry
yarn add -D typescript types-for-adobe@https://github.com/vespakoen/Types-For-Adobe

# create tsconfig.json
printf '{"compilerOptions":{"module":"none","noLib":true, "types": ["types-for-adobe/shared", "types-for-adobe/AfterEffects/18.0"]}}' > tsconfig.json

# create index.ts and change reference types to Adobe product you're targeting
printf 'alert(String(app));\n' > index.ts

# compile typescript files
yarn tsc
```