### PR TITLE
fix: correct indexed access for audio clip collections

### DIFF
--- a/Audition/2018/index.d.ts
+++ b/Audition/2018/index.d.ts
@@ -451,7 +451,7 @@ declare class AudioClipSelectionCollection {
   /**
    * Returns an audio clip by its index
    */
-  readonly index: AudioClipCollection
+  [index: number]: AudioClipCollection
 
   /**
    * Number of audio clips.
@@ -533,7 +533,7 @@ declare class AudioClipCollection {
   /**
    * Returns an audio clip by its index
    */
-  readonly index: AudioClipCollection
+  [index: number]: AudioClip
 
   /**
    * Number of audio clips.


### PR DESCRIPTION
- Fix AudioClipSelectionCollection and AudioClipCollection indexers.
- Change AudioClipCollection indexer to return AudioClip instead of AudioClipCollection.