### PR TITLE
ILST: Fix/private constructor dom classes

### DIFF
--- a/Illustrator/2015.3/index.d.ts
+++ b/Illustrator/2015.3/index.d.ts
@@ -3670,6 +3670,8 @@ declare enum DocumentLayoutStyle {
  * A collection of artboards.
  */
 declare class Artboards extends Array<Artboard> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -3737,6 +3739,8 @@ declare class Artboards extends Array<Artboard> {
  * A collection of documents.
  */
 declare class Documents extends Array<Document> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -3808,6 +3812,8 @@ declare class Documents extends Array<Document> {
  * A collection of layers.
  */
 declare class Layers extends Array<Layer> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -3844,6 +3850,8 @@ declare class Layers extends Array<Layer> {
  * A collection of group items.
  */
 declare class GroupItems extends Array<GroupItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -3886,6 +3894,8 @@ declare class GroupItems extends Array<GroupItem> {
  * A collection of page items.
  */
 declare class PageItems extends Array<PageItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -3912,6 +3922,8 @@ declare class PageItems extends Array<PageItem> {
  * A collection of path items.
  */
 declare class PathItems extends Array<PathItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4030,6 +4042,8 @@ declare class PathItems extends Array<PathItem> {
  * A collection of path points.
  */
 declare class PathPoints extends Array<PathPoint> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4066,6 +4080,8 @@ declare class PathPoints extends Array<PathPoint> {
  * A collection of compound path items.
  */
 declare class CompoundPathItems extends Array<CompoundPathItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4102,6 +4118,8 @@ declare class CompoundPathItems extends Array<CompoundPathItem> {
  * A collection of stories.
  */
 declare class Stories extends Array<Story> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4128,6 +4146,8 @@ declare class Stories extends Array<Story> {
  * A collection of text frame items.
  */
 declare class TextFrameItems extends Array<TextFrame> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4203,6 +4223,8 @@ declare class TextFrameItems extends Array<TextFrame> {
  * A collection of legacy text items.
  */
 declare class LegacyTextItems extends Array<LegacyTextItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4234,6 +4256,8 @@ declare class LegacyTextItems extends Array<LegacyTextItem> {
  * A collection of text range items.
  */
 declare class TextRanges extends Array<TextRange> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4260,6 +4284,8 @@ declare class TextRanges extends Array<TextRange> {
  * A collection of insertion points.
  */
 declare class InsertionPoints extends Array<InsertionPoint> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4286,6 +4312,8 @@ declare class InsertionPoints extends Array<InsertionPoint> {
  * A collection of characters.
  */
 declare class Characters extends Array<TextRange> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4329,6 +4357,8 @@ declare class Characters extends Array<TextRange> {
  * A collection of words.
  */
 declare class Words extends Array<TextRange> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4372,6 +4402,8 @@ declare class Words extends Array<TextRange> {
  * A collection of lines.
  */
 declare class Lines extends Array<TextRange> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4398,6 +4430,8 @@ declare class Lines extends Array<TextRange> {
  * A collection of Paragraphs.
  */
 declare class Paragraphs extends Array<TextRange> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4441,6 +4475,8 @@ declare class Paragraphs extends Array<TextRange> {
  * A collection of character styles.
  */
 declare class CharacterStyles extends Array<CharacterStyle> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4478,6 +4514,8 @@ declare class CharacterStyles extends Array<CharacterStyle> {
  * A collection of paragraph styles.
  */
 declare class ParagraphStyles extends Array<ParagraphStyle> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4515,6 +4553,8 @@ declare class ParagraphStyles extends Array<ParagraphStyle> {
  * A collection of custom spot colors.
  */
 declare class Spots extends Array<Spot> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4551,6 +4591,8 @@ declare class Spots extends Array<Spot> {
  * A collection of swatches.
  */
 declare class Swatches extends Array<Swatch> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4593,6 +4635,8 @@ declare class Swatches extends Array<Swatch> {
  * A collection of Swatch groups.
  */
 declare class SwatchGroups extends Array<SwatchGroup> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4634,6 +4678,8 @@ declare class SwatchGroups extends Array<SwatchGroup> {
  * A collection of gradients.
  */
 declare class Gradients extends Array<Gradient> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4670,6 +4716,8 @@ declare class Gradients extends Array<Gradient> {
  * A collection of gradient stops.
  */
 declare class GradientStops extends Array<GradientStop> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4706,6 +4754,8 @@ declare class GradientStops extends Array<GradientStop> {
  * A collection of patterns.
  */
 declare class Patterns extends Array<Pattern> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4742,6 +4792,8 @@ declare class Patterns extends Array<Pattern> {
  * A collection of symbols.
  */
 declare class Symbols extends Array<Symbol> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4780,6 +4832,8 @@ declare class Symbols extends Array<Symbol> {
  * A collection of symbol items.
  */
 declare class SymbolItems extends Array<SymbolItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4817,6 +4871,8 @@ declare class SymbolItems extends Array<SymbolItem> {
  * A collection of brushes.
  */
 declare class Brushes extends Array<Brush> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4856,6 +4912,8 @@ declare class Brushes extends Array<Brush> {
  * A collection of art styles.
  */
 declare class ArtStyles extends Array<ArtStyle> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4887,6 +4945,8 @@ declare class ArtStyles extends Array<ArtStyle> {
  * A collection of fonts.
  */
 declare class TextFonts extends Array<TextFont> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4930,6 +4990,8 @@ declare class TextFonts extends Array<TextFont> {
  * The collection of tags associated with a page item.
  */
 declare class Tags extends Array<Tag> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4966,6 +5028,8 @@ declare class Tags extends Array<Tag> {
  * A collection of RasterItems.
  */
 declare class RasterItems extends Array<RasterItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4997,6 +5061,8 @@ declare class RasterItems extends Array<RasterItem> {
  * A collection of PlacedItems.
  */
 declare class PlacedItems extends Array<PlacedItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5033,6 +5099,8 @@ declare class PlacedItems extends Array<PlacedItem> {
  * EmbeddedItems Collection.
  */
 declare class EmbeddedItems extends Array<EmbedItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5069,6 +5137,8 @@ declare class EmbeddedItems extends Array<EmbedItem> {
  * A collection of MeshItems.
  */
 declare class MeshItems extends Array<MeshItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5100,6 +5170,8 @@ declare class MeshItems extends Array<MeshItem> {
  * A collection of GraphItems.
  */
 declare class GraphItems extends Array<GraphItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5131,6 +5203,8 @@ declare class GraphItems extends Array<GraphItem> {
  * A collection of PluginItems.
  */
 declare class PluginItems extends Array<PluginItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5162,6 +5236,8 @@ declare class PluginItems extends Array<PluginItem> {
  * A collection of NonNativeItems.
  */
 declare class NonNativeItems extends Array<NonNativeItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5188,6 +5264,8 @@ declare class NonNativeItems extends Array<NonNativeItem> {
  * A collection of views.
  */
 declare class Views extends Array<View> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5214,6 +5292,8 @@ declare class Views extends Array<View> {
  * A collection of variables.
  */
 declare class Variables extends Array<Variable> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5250,6 +5330,8 @@ declare class Variables extends Array<Variable> {
  * A collection of datasets.
  */
 declare class DataSets extends Array<DataSet> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -7636,6 +7718,8 @@ declare class RasterizeOptions {
  * The Adobe Illustrator application.
  */
 declare class Application {
+  private constructor()
+
   /**
    * The list of PDF preset names currently available for use.
    */
@@ -8310,6 +8394,8 @@ declare class Application {
  * A document.
  */
 declare class Document {
+  private constructor()
+
   /**
    * The XMP packet string associated with the document.
    */
@@ -8930,6 +9016,8 @@ declare class Document {
  * A layer.
  */
 declare class Layer {
+  private constructor()
+
   /**
    * The absolute drawing order of the layer.
    */
@@ -9113,6 +9201,8 @@ declare class Layer {
  * A view.
  */
 declare class View {
+  private constructor()
+
   /**
    * The bounding rectangle of this view.
    */
@@ -9148,6 +9238,8 @@ declare class View {
  * A gradient.
  */
 declare class Gradient {
+  private constructor()
+
   /**
    * The stops in this gradient.
    */
@@ -9188,6 +9280,8 @@ declare class Gradient {
  * A gradient stop.
  */
 declare class GradientStop {
+  private constructor()
+
   /**
    * The color linked to this gradient stop.
    */
@@ -9233,6 +9327,8 @@ declare class GradientStop {
  * Preferences for Illustrator.
  */
 declare class Preferences {
+  private constructor()
+
   /**
    * Options to use when opening or placing a AutoCAD file.
    */
@@ -9321,6 +9417,8 @@ declare class Preferences {
  * A custom color.
  */
 declare class Spot {
+  private constructor()
+
   /**
    *
    */
@@ -9371,6 +9469,8 @@ declare class Spot {
  * Dynamic object used to create data-driven graphics.
  */
 declare class Variable {
+  private constructor()
+
   /**
    * The variable's type.
    */
@@ -9411,6 +9511,8 @@ declare class Variable {
  * A set of variables and their associated dynamic data which will be used for dynamic publishing.
  */
 declare class DataSet {
+  private constructor()
+
   /**
    * The name of this dataset.
    */
@@ -9451,6 +9553,8 @@ declare class DataSet {
  * A color swatch.
  */
 declare class Swatch {
+  private constructor()
+
   /**
    * The color information of the swatch.
    */
@@ -9486,6 +9590,8 @@ declare class Swatch {
  * A Swatch group.
  */
 declare class SwatchGroup {
+  private constructor()
+
   /**
    * Name of the swatch group.
    */
@@ -9533,6 +9639,8 @@ declare class SwatchGroup {
  * A pattern.
  */
 declare class Pattern {
+  private constructor()
+
   /**
    * The pattern's name.
    */
@@ -9563,6 +9671,8 @@ declare class Pattern {
  * A symbol.
  */
 declare class Symbol {
+  private constructor()
+
   /**
    * The symbol's name.
    */
@@ -9600,6 +9710,8 @@ declare class Symbol {
  * A brush.
  */
 declare class Brush {
+  private constructor()
+
   /**
    * The brush's name.
    */
@@ -9626,6 +9738,8 @@ declare class Brush {
  * An art style.
  */
 declare class ArtStyle {
+  private constructor()
+
   /**
    * The art style's name.
    */
@@ -9668,6 +9782,8 @@ declare class ArtStyle {
  * An installed font.
  */
 declare class TextFont {
+  private constructor()
+
   /**
    * The font's family name.
    */
@@ -9992,6 +10108,8 @@ declare class PageItem {
  * Compound path artwork item.
  */
 declare class CompoundPathItem extends PageItem {
+  private constructor()
+
   /**
    * The path artwork in this compound path.
    */
@@ -10002,6 +10120,8 @@ declare class CompoundPathItem extends PageItem {
  * A tag associated with a piece of artwork.
  */
 declare class Tag {
+  private constructor()
+
   /**
    * The tag's name.
    */
@@ -10037,6 +10157,8 @@ declare class Tag {
  * An artwork path item.
  */
 declare class PathItem extends PageItem {
+  private constructor()
+
   /**
    * The area of this path in square points.
    */
@@ -10158,6 +10280,8 @@ declare class PathItem extends PageItem {
  * A point on a path.
  */
 declare class PathPoint {
+  private constructor()
+
   /**
    * The position (coordinates) of the anchor point.
    */
@@ -10208,6 +10332,8 @@ declare class PathPoint {
  * Raster artwork item.
  */
 declare class RasterItem extends PageItem {
+  private constructor()
+
   /**
    * The number of bits per channel.
    */
@@ -10289,6 +10415,8 @@ declare class RasterItem extends PageItem {
  * Placed artwork item.
  */
 declare class PlacedItem extends PageItem {
+  private constructor()
+
   /**
    * Dimensions of placed art object, regardless of transformations.
    */
@@ -10330,6 +10458,8 @@ declare class PlacedItem extends PageItem {
  * Embedded artwork item.
  */
 declare class EmbedItem extends PageItem {
+  private constructor()
+
   /**
    * The file containing the placed artwork.
    */
@@ -10340,6 +10470,8 @@ declare class EmbedItem extends PageItem {
  * Graph artwork item.
  */
 declare class GraphItem extends PageItem {
+  private constructor()
+
   /**
    * The content variable bound to this graph.
    */
@@ -10349,17 +10481,23 @@ declare class GraphItem extends PageItem {
 /**
  * Non-native artwork item.
  */
-declare class NonNativeItem extends PageItem {}
+declare class NonNativeItem extends PageItem {
+  private constructor()
+}
 
 /**
  * Mesh artwork item.
  */
-declare class MeshItem extends PageItem {}
+declare class MeshItem extends PageItem {
+  private constructor()
+}
 
 /**
  * Plugin artwork item.
  */
 declare class PluginItem extends PageItem {
+  private constructor()
+
   /**
    * Is the plugin group a tracing?
    */
@@ -10375,6 +10513,8 @@ declare class PluginItem extends PageItem {
  * An artwork group item.
  */
 declare class GroupItem extends PageItem {
+  private constructor()
+
   /**
    * Are the group elements clipped to the clipping path?
    */
@@ -10450,6 +10590,8 @@ declare class GroupItem extends PageItem {
  * An instance of a Symbol.
  */
 declare class SymbolItem extends PageItem {
+  private constructor()
+
   /**
    * The symbol that was used to create this symbol item.
    */
@@ -10465,6 +10607,8 @@ declare class SymbolItem extends PageItem {
  * A text path item.
  */
 declare class TextPath {
+  private constructor()
+
   /**
    * The area of this path in square points.
    */
@@ -10636,6 +10780,8 @@ declare class TextPath {
  * A contiguous block of text.
  */
 declare class Story {
+  private constructor()
+
   /**
    * All the characters in this text range.
    */
@@ -10701,6 +10847,8 @@ declare class Story {
  * Text frame item.
  */
 declare class TextFrame extends PageItem {
+  private constructor()
+
   /**
    * The position of the anchor point (start of base line for point text)
    */
@@ -10885,6 +11033,8 @@ declare class TextFrame extends PageItem {
  * Unconverted legacy text items from documents in pre-version 11 formats.
  */
 declare class LegacyTextItem extends PageItem {
+  private constructor()
+
   /**
    * Has the legacy text item been updated to a native text frame item?
    */
@@ -10900,6 +11050,8 @@ declare class LegacyTextItem extends PageItem {
  * A range of characters from a text item.
  */
 declare class TextRange {
+  private constructor()
+
   /**
    * The character properties for the text range.
    */
@@ -11036,6 +11188,8 @@ declare class TextRange {
  * A location between characters, used to insert new text objects.
  */
 declare class InsertionPoint {
+  private constructor()
+
   /**
    * All the characters in this text range.
    */
@@ -11081,6 +11235,8 @@ declare class InsertionPoint {
  * A named style that remembers character attributes.
  */
 declare class CharacterStyle {
+  private constructor()
+
   /**
    * The character properties for the text range.
    */
@@ -11133,6 +11289,8 @@ declare class CharacterStyle {
  * A named style that remembers paragraph attributes.
  */
 declare class ParagraphStyle {
+  private constructor()
+
   /**
    * The character properties for the text range.
    */
@@ -11190,6 +11348,8 @@ declare class ParagraphStyle {
  * Properties of a character.
  */
 declare class CharacterAttributes {
+  private constructor()
+
   /**
    * The percentage of space reduction around a Japanese character (100 = 100%)
    */
@@ -11455,6 +11615,8 @@ declare class CharacterAttributes {
  * Properties of a paragraph.
  */
 declare class ParagraphAttributes {
+  private constructor()
+
   /**
    * Auto leading amount (in percentage)
    */
@@ -11645,6 +11807,8 @@ declare class ParagraphAttributes {
  * Options which are applied when opening or placing a Photoshop file.
  */
 declare class OpenOptionsPhotoshop {
+  private constructor()
+
   /**
    * Should use the specified LayerComp.
    */
@@ -11685,6 +11849,8 @@ declare class OpenOptionsPhotoshop {
  * Options which may be supplied when opening a PDF file.
  */
 declare class OpenOptionsPDF {
+  private constructor()
+
   /**
    * What box should be used when placing a multipage document (default: PDF media box)
    */
@@ -11710,6 +11876,8 @@ declare class OpenOptionsPDF {
  * Options which may be supplied when opening a AutoCAD file.
  */
 declare class OpenOptionsAutoCAD {
+  private constructor()
+
   /**
    * To center the created artwork on the artboard (default: true)
    */
@@ -11765,6 +11933,8 @@ declare class OpenOptionsAutoCAD {
  * Tracing options that guide the tracing process.
  */
 declare class TracingOptions {
+  private constructor()
+
   /**
    * ColorFidelity when TracingColorTypeValue is TracingFullColor.
    */
@@ -11887,6 +12057,8 @@ declare class TracingOptions {
  * A tracing object.
  */
 declare class TracingObject {
+  private constructor()
+
   /**
    * The number of anchors in the tracing result.
    */
@@ -11938,6 +12110,8 @@ declare class TracingObject {
  * An artboard object.
  */
 declare class Artboard {
+  private constructor()
+
   /**
    * Size and position of artboard.
    */

--- a/Illustrator/2022/index.d.ts
+++ b/Illustrator/2022/index.d.ts
@@ -3670,6 +3670,8 @@ declare enum DocumentLayoutStyle {
  * A collection of artboards.
  */
 declare class Artboards extends Array<Artboard> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -3737,6 +3739,8 @@ declare class Artboards extends Array<Artboard> {
  * A collection of documents.
  */
 declare class Documents extends Array<Document> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -3808,6 +3812,8 @@ declare class Documents extends Array<Document> {
  * A collection of layers.
  */
 declare class Layers extends Array<Layer> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -3844,6 +3850,8 @@ declare class Layers extends Array<Layer> {
  * A collection of group items.
  */
 declare class GroupItems extends Array<GroupItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -3886,6 +3894,8 @@ declare class GroupItems extends Array<GroupItem> {
  * A collection of page items.
  */
 declare class PageItems extends Array<PageItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -3912,6 +3922,8 @@ declare class PageItems extends Array<PageItem> {
  * A collection of path items.
  */
 declare class PathItems extends Array<PathItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4030,6 +4042,8 @@ declare class PathItems extends Array<PathItem> {
  * A collection of path points.
  */
 declare class PathPoints extends Array<PathPoint> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4066,6 +4080,8 @@ declare class PathPoints extends Array<PathPoint> {
  * A collection of compound path items.
  */
 declare class CompoundPathItems extends Array<CompoundPathItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4102,6 +4118,8 @@ declare class CompoundPathItems extends Array<CompoundPathItem> {
  * A collection of stories.
  */
 declare class Stories extends Array<Story> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4128,6 +4146,8 @@ declare class Stories extends Array<Story> {
  * A collection of text frame items.
  */
 declare class TextFrameItems extends Array<TextFrame> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4203,6 +4223,8 @@ declare class TextFrameItems extends Array<TextFrame> {
  * A collection of legacy text items.
  */
 declare class LegacyTextItems extends Array<LegacyTextItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4234,6 +4256,8 @@ declare class LegacyTextItems extends Array<LegacyTextItem> {
  * A collection of text range items.
  */
 declare class TextRanges extends Array<TextRange> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4260,6 +4284,8 @@ declare class TextRanges extends Array<TextRange> {
  * A collection of insertion points.
  */
 declare class InsertionPoints extends Array<InsertionPoint> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4286,6 +4312,8 @@ declare class InsertionPoints extends Array<InsertionPoint> {
  * A collection of characters.
  */
 declare class Characters extends Array<TextRange> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4329,6 +4357,8 @@ declare class Characters extends Array<TextRange> {
  * A collection of words.
  */
 declare class Words extends Array<TextRange> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4372,6 +4402,8 @@ declare class Words extends Array<TextRange> {
  * A collection of lines.
  */
 declare class Lines extends Array<TextRange> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4398,6 +4430,8 @@ declare class Lines extends Array<TextRange> {
  * A collection of Paragraphs.
  */
 declare class Paragraphs extends Array<TextRange> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4441,6 +4475,8 @@ declare class Paragraphs extends Array<TextRange> {
  * A collection of character styles.
  */
 declare class CharacterStyles extends Array<CharacterStyle> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4478,6 +4514,8 @@ declare class CharacterStyles extends Array<CharacterStyle> {
  * A collection of paragraph styles.
  */
 declare class ParagraphStyles extends Array<ParagraphStyle> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4515,6 +4553,8 @@ declare class ParagraphStyles extends Array<ParagraphStyle> {
  * A collection of custom spot colors.
  */
 declare class Spots extends Array<Spot> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4551,6 +4591,8 @@ declare class Spots extends Array<Spot> {
  * A collection of swatches.
  */
 declare class Swatches extends Array<Swatch> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4593,6 +4635,8 @@ declare class Swatches extends Array<Swatch> {
  * A collection of Swatch groups.
  */
 declare class SwatchGroups extends Array<SwatchGroup> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4634,6 +4678,8 @@ declare class SwatchGroups extends Array<SwatchGroup> {
  * A collection of gradients.
  */
 declare class Gradients extends Array<Gradient> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4670,6 +4716,8 @@ declare class Gradients extends Array<Gradient> {
  * A collection of gradient stops.
  */
 declare class GradientStops extends Array<GradientStop> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4706,6 +4754,8 @@ declare class GradientStops extends Array<GradientStop> {
  * A collection of patterns.
  */
 declare class Patterns extends Array<Pattern> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4742,6 +4792,8 @@ declare class Patterns extends Array<Pattern> {
  * A collection of symbols.
  */
 declare class Symbols extends Array<Symbol> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4780,6 +4832,8 @@ declare class Symbols extends Array<Symbol> {
  * A collection of symbol items.
  */
 declare class SymbolItems extends Array<SymbolItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4817,6 +4871,8 @@ declare class SymbolItems extends Array<SymbolItem> {
  * A collection of brushes.
  */
 declare class Brushes extends Array<Brush> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4856,6 +4912,8 @@ declare class Brushes extends Array<Brush> {
  * A collection of art styles.
  */
 declare class ArtStyles extends Array<ArtStyle> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4887,6 +4945,8 @@ declare class ArtStyles extends Array<ArtStyle> {
  * A collection of fonts.
  */
 declare class TextFonts extends Array<TextFont> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4930,6 +4990,8 @@ declare class TextFonts extends Array<TextFont> {
  * The collection of tags associated with a page item.
  */
 declare class Tags extends Array<Tag> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4966,6 +5028,8 @@ declare class Tags extends Array<Tag> {
  * A collection of RasterItems.
  */
 declare class RasterItems extends Array<RasterItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -4997,6 +5061,8 @@ declare class RasterItems extends Array<RasterItem> {
  * A collection of PlacedItems.
  */
 declare class PlacedItems extends Array<PlacedItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5033,6 +5099,8 @@ declare class PlacedItems extends Array<PlacedItem> {
  * EmbeddedItems Collection.
  */
 declare class EmbeddedItems extends Array<EmbedItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5069,6 +5137,8 @@ declare class EmbeddedItems extends Array<EmbedItem> {
  * A collection of MeshItems.
  */
 declare class MeshItems extends Array<MeshItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5100,6 +5170,8 @@ declare class MeshItems extends Array<MeshItem> {
  * A collection of GraphItems.
  */
 declare class GraphItems extends Array<GraphItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5131,6 +5203,8 @@ declare class GraphItems extends Array<GraphItem> {
  * A collection of PluginItems.
  */
 declare class PluginItems extends Array<PluginItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5162,6 +5236,8 @@ declare class PluginItems extends Array<PluginItem> {
  * A collection of NonNativeItems.
  */
 declare class NonNativeItems extends Array<NonNativeItem> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5188,6 +5264,8 @@ declare class NonNativeItems extends Array<NonNativeItem> {
  * A collection of views.
  */
 declare class Views extends Array<View> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5214,6 +5292,8 @@ declare class Views extends Array<View> {
  * A collection of variables.
  */
 declare class Variables extends Array<Variable> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -5250,6 +5330,8 @@ declare class Variables extends Array<Variable> {
  * A collection of datasets.
  */
 declare class DataSets extends Array<DataSet> {
+  private constructor()
+
   /**
    * Number of elements in the collection.
    */
@@ -7636,6 +7718,8 @@ declare class RasterizeOptions {
  * The Adobe Illustrator application.
  */
 declare class Application {
+  private constructor()
+
   /**
    * The list of PDF preset names currently available for use.
    */
@@ -8310,6 +8394,8 @@ declare class Application {
  * A document.
  */
 declare class Document {
+  private constructor()
+
   /**
    * The XMP packet string associated with the document.
    */
@@ -8930,6 +9016,8 @@ declare class Document {
  * A layer.
  */
 declare class Layer {
+  private constructor()
+
   /**
    * The absolute drawing order of the layer.
    */
@@ -9113,6 +9201,8 @@ declare class Layer {
  * A view.
  */
 declare class View {
+  private constructor()
+
   /**
    * The bounding rectangle of this view.
    */
@@ -9148,6 +9238,8 @@ declare class View {
  * A gradient.
  */
 declare class Gradient {
+  private constructor()
+
   /**
    * The stops in this gradient.
    */
@@ -9188,6 +9280,8 @@ declare class Gradient {
  * A gradient stop.
  */
 declare class GradientStop {
+  private constructor()
+
   /**
    * The color linked to this gradient stop.
    */
@@ -9233,6 +9327,8 @@ declare class GradientStop {
  * Preferences for Illustrator.
  */
 declare class Preferences {
+  private constructor()
+
   /**
    * Options to use when opening or placing a AutoCAD file.
    */
@@ -9321,6 +9417,8 @@ declare class Preferences {
  * A custom color.
  */
 declare class Spot {
+  private constructor()
+
   /**
    *
    */
@@ -9371,6 +9469,8 @@ declare class Spot {
  * Dynamic object used to create data-driven graphics.
  */
 declare class Variable {
+  private constructor()
+
   /**
    * The variable's type.
    */
@@ -9411,6 +9511,8 @@ declare class Variable {
  * A set of variables and their associated dynamic data which will be used for dynamic publishing.
  */
 declare class DataSet {
+  private constructor()
+
   /**
    * The name of this dataset.
    */
@@ -9451,6 +9553,8 @@ declare class DataSet {
  * A color swatch.
  */
 declare class Swatch {
+  private constructor()
+
   /**
    * The color information of the swatch.
    */
@@ -9486,6 +9590,8 @@ declare class Swatch {
  * A Swatch group.
  */
 declare class SwatchGroup {
+  private constructor()
+
   /**
    * Name of the swatch group.
    */
@@ -9533,6 +9639,8 @@ declare class SwatchGroup {
  * A pattern.
  */
 declare class Pattern {
+  private constructor()
+
   /**
    * The pattern's name.
    */
@@ -9563,6 +9671,8 @@ declare class Pattern {
  * A symbol.
  */
 declare class Symbol {
+  private constructor()
+
   /**
    * The symbol's name.
    */
@@ -9600,6 +9710,8 @@ declare class Symbol {
  * A brush.
  */
 declare class Brush {
+  private constructor()
+
   /**
    * The brush's name.
    */
@@ -9626,6 +9738,8 @@ declare class Brush {
  * An art style.
  */
 declare class ArtStyle {
+  private constructor()
+
   /**
    * The art style's name.
    */
@@ -9668,6 +9782,8 @@ declare class ArtStyle {
  * An installed font.
  */
 declare class TextFont {
+  private constructor()
+
   /**
    * The font's family name.
    */
@@ -9992,6 +10108,8 @@ declare class PageItem {
  * Compound path artwork item.
  */
 declare class CompoundPathItem extends PageItem {
+  private constructor()
+
   /**
    * Unique Identifier of the Path
    */
@@ -10006,6 +10124,8 @@ declare class CompoundPathItem extends PageItem {
  * A tag associated with a piece of artwork.
  */
 declare class Tag {
+  private constructor()
+
   /**
    * The tag's name.
    */
@@ -10041,6 +10161,8 @@ declare class Tag {
  * An artwork path item.
  */
 declare class PathItem extends PageItem {
+  private constructor()
+
   /**
    * Unique Identifier of the Path
    */
@@ -10180,6 +10302,8 @@ declare class PathItem extends PageItem {
  * A point on a path.
  */
 declare class PathPoint {
+  private constructor()
+
   /**
    * The position (coordinates) of the anchor point.
    */
@@ -10230,6 +10354,8 @@ declare class PathPoint {
  * Raster artwork item.
  */
 declare class RasterItem extends PageItem {
+  private constructor()
+
   /**
    * The number of bits per channel.
    */
@@ -10311,6 +10437,8 @@ declare class RasterItem extends PageItem {
  * Placed artwork item.
  */
 declare class PlacedItem extends PageItem {
+  private constructor()
+
   /**
    * Dimensions of placed art object, regardless of transformations.
    */
@@ -10352,6 +10480,8 @@ declare class PlacedItem extends PageItem {
  * Embedded artwork item.
  */
 declare class EmbedItem extends PageItem {
+  private constructor()
+
   /**
    * The file containing the placed artwork.
    */
@@ -10362,6 +10492,8 @@ declare class EmbedItem extends PageItem {
  * Graph artwork item.
  */
 declare class GraphItem extends PageItem {
+  private constructor()
+
   /**
    * The content variable bound to this graph.
    */
@@ -10371,17 +10503,23 @@ declare class GraphItem extends PageItem {
 /**
  * Non-native artwork item.
  */
-declare class NonNativeItem extends PageItem {}
+declare class NonNativeItem extends PageItem {
+  private constructor()
+}
 
 /**
  * Mesh artwork item.
  */
-declare class MeshItem extends PageItem {}
+declare class MeshItem extends PageItem {
+  private constructor()
+}
 
 /**
  * Plugin artwork item.
  */
 declare class PluginItem extends PageItem {
+  private constructor()
+
   /**
    * Is the plugin group a tracing?
    */
@@ -10397,6 +10535,8 @@ declare class PluginItem extends PageItem {
  * An artwork group item.
  */
 declare class GroupItem extends PageItem {
+  private constructor()
+
   /**
    * Are the group elements clipped to the clipping path?
    */
@@ -10472,6 +10612,8 @@ declare class GroupItem extends PageItem {
  * An instance of a Symbol.
  */
 declare class SymbolItem extends PageItem {
+  private constructor()
+
   /**
    * The symbol that was used to create this symbol item.
    */
@@ -10487,6 +10629,8 @@ declare class SymbolItem extends PageItem {
  * A text path item.
  */
 declare class TextPath {
+  private constructor()
+
   /**
    * The area of this path in square points.
    */
@@ -10658,6 +10802,8 @@ declare class TextPath {
  * A contiguous block of text.
  */
 declare class Story {
+  private constructor()
+
   /**
    * All the characters in this text range.
    */
@@ -10723,6 +10869,8 @@ declare class Story {
  * Text frame item.
  */
 declare class TextFrame extends PageItem {
+  private constructor()
+
   /**
    * The position of the anchor point (start of base line for point text)
    */
@@ -10907,6 +11055,8 @@ declare class TextFrame extends PageItem {
  * Unconverted legacy text items from documents in pre-version 11 formats.
  */
 declare class LegacyTextItem extends PageItem {
+  private constructor()
+
   /**
    * Has the legacy text item been updated to a native text frame item?
    */
@@ -10922,6 +11072,8 @@ declare class LegacyTextItem extends PageItem {
  * A range of characters from a text item.
  */
 declare class TextRange {
+  private constructor()
+
   /**
    * The character properties for the text range.
    */
@@ -11058,6 +11210,8 @@ declare class TextRange {
  * A location between characters, used to insert new text objects.
  */
 declare class InsertionPoint {
+  private constructor()
+
   /**
    * All the characters in this text range.
    */
@@ -11103,6 +11257,8 @@ declare class InsertionPoint {
  * A named style that remembers character attributes.
  */
 declare class CharacterStyle {
+  private constructor()
+
   /**
    * The character properties for the text range.
    */
@@ -11155,6 +11311,8 @@ declare class CharacterStyle {
  * A named style that remembers paragraph attributes.
  */
 declare class ParagraphStyle {
+  private constructor()
+
   /**
    * The character properties for the text range.
    */
@@ -11212,6 +11370,8 @@ declare class ParagraphStyle {
  * Properties of a character.
  */
 declare class CharacterAttributes {
+  private constructor()
+
   /**
    * The percentage of space reduction around a Japanese character (100 = 100%)
    */
@@ -11477,6 +11637,8 @@ declare class CharacterAttributes {
  * Properties of a paragraph.
  */
 declare class ParagraphAttributes {
+  private constructor()
+
   /**
    * Auto leading amount (in percentage)
    */
@@ -11667,6 +11829,8 @@ declare class ParagraphAttributes {
  * Options which are applied when opening or placing a Photoshop file.
  */
 declare class OpenOptionsPhotoshop {
+  private constructor()
+
   /**
    * Should use the specified LayerComp.
    */
@@ -11707,6 +11871,8 @@ declare class OpenOptionsPhotoshop {
  * Options which may be supplied when opening a PDF file.
  */
 declare class OpenOptionsPDF {
+  private constructor()
+
   /**
    * What box should be used when placing a multipage document (default: PDF media box)
    */
@@ -11732,6 +11898,8 @@ declare class OpenOptionsPDF {
  * Options which may be supplied when opening a AutoCAD file.
  */
 declare class OpenOptionsAutoCAD {
+  private constructor()
+
   /**
    * To center the created artwork on the artboard (default: true)
    */
@@ -11787,6 +11955,8 @@ declare class OpenOptionsAutoCAD {
  * Tracing options that guide the tracing process.
  */
 declare class TracingOptions {
+  private constructor()
+
   /**
    * ColorFidelity when TracingColorTypeValue is TracingFullColor.
    */
@@ -11909,6 +12079,8 @@ declare class TracingOptions {
  * A tracing object.
  */
 declare class TracingObject {
+  private constructor()
+
   /**
    * The number of anchors in the tracing result.
    */
@@ -11960,6 +12132,8 @@ declare class TracingObject {
  * An artboard object.
  */
 declare class Artboard {
+  private constructor()
+
   /**
    * Size and position of artboard.
    */


### PR DESCRIPTION
Many Illustrator DOM classes cannot be instantiated from user code — e.g. `new Layer()`, `new Document()`, `new PageItems()` all throw at runtime ("does not have a constructor" or the class has no global). These objects are handed to the script by the host: `app.documents`, `doc.layers`, `app.preferences`, `doc.pageItems[0]`, etc. New instances can only be created through other Illustrator methods like `app.activeDocument.layers.add()` etc.

The TypeScript typedef previously allowed `new X()` for every class, which caught no misuse. `private constructor()` makes these misuses a compile error while still letting the class name be used as a type.

Base classes Color and PageItem are intentionally left with a public constructor so their existing subclasses (LabColor, PathItem, …) can still extend them.

Note this was tested in the same ways as my other [PR-159](https://github.com/docsforadobe/Types-for-Adobe/pull/159) with a short test script executed in Illustrator 2026 and 2025. But I'm quite sure that was already the case in older Illustrator versions.

<details>
<summary>The jsx script used to identify this.</summary>

```js
/*
 * Illustrator ExtendScript reflect probe.
 *
 * For every Illustrator scripting class this script answers two questions:
 *
 *   1. Can user code `new ClassName()`?
 *        → try constructing. If the engine rejects the call (no global, or
 *          "does not have a constructor"), the TypeScript typedef must mark
 *          the class with `private constructor()` so `new X()` is a type
 *          error. Otherwise the default public constructor is correct.
 *
 *   2. What is the real public API of an instance?
 *        → walk `instance.reflect.properties` and `instance.reflect.methods`.
 *          Everything that surfaces here is an instance (a.k.a. public)
 *          member. This is the authoritative list for the typedef body.
 *
 * Note on "static": ExtendScript's class dictionaries mirror the instance
 * schema onto the constructor (reading `Paper.paperInfo` returns a metadata
 * handle, and writing to it persists as a plain Function-object property).
 * That is not a real static member — it is a quirk of the engine's
 * introspection. Only instance reflection is reported below, so the report
 * lines up 1:1 with how the API is actually used and typed.
 *
 * Usage:
 *   1. Open Illustrator 2022 (or newer).
 *   2. Open at least one document (classes like Layer, Swatch, TextFrame
 *      only exist inside a document).
 *   3. File > Scripts > Other Script… > select this file.
 *   4. Report is written to ~/Desktop/ai-reflect-report.txt.
 */

#target illustrator

(function () {
  var out = [];
  function log(s) { out.push(s); }

  // Members every ExtendScript object carries; not part of the class's API.
  var BUILTINS = { __proto__: 1, reflect: 1 };

  function listMembers(members) {
    var a = [];
    for (var i = 0; i < members.length; i++) {
      var name = members[i].name;
      if (BUILTINS[name]) continue;
      a.push(name);
    }
    a.sort();
    return a;
  }

  // Try to build an instance. Returns {ok, instance, reason}.
  //   ok=true  → `new X()` works, keep default public constructor in typedef.
  //   ok=false → typedef needs `private constructor()`.
  function tryConstruct(name) {
    var ctor;
    try { ctor = $.global[name]; } catch (e) {
      return { ok: false, reason: "no global '" + name + "'" };
    }
    if (typeof ctor === "undefined" || ctor === null) {
      return { ok: false, reason: "no global '" + name + "'" };
    }
    try {
      var inst = new ctor();
      return { ok: true, instance: inst };
    } catch (e) {
      return { ok: false, reason: "new " + name + "() threw: " + e };
    }
  }

  function probe(entry) {
    log("================ " + entry.name + " ================");

    // 1. Constructor check — drives `private constructor()` decision.
    var ctorCheck = tryConstruct(entry.name);
    if (ctorCheck.ok) {
      log("  constructor: public  (new " + entry.name + "() succeeded)");
    } else {
      log("  constructor: private (" + ctorCheck.reason + ")");
    }

    // 2. Instance API — drives the typedef body.
    var inst = ctorCheck.ok ? ctorCheck.instance : null;
    if (!inst) {
      try { inst = entry.sample(); } catch (e) {
        log("  (no live instance: " + e + ")");
        log("");
        return;
      }
    }
    if (!inst) {
      log("  (no live instance available" + (entry.note ? " — " + entry.note : "") + ")");
      log("");
      return;
    }

    try {
      var props   = listMembers(inst.reflect.properties);
      var methods = listMembers(inst.reflect.methods);
      log("  props:   " + (props.length   ? props.join(", ")   : "—"));
      log("  methods: " + (methods.length ? methods.join(", ") : "—"));
    } catch (e) {
      log("  reflect failed on instance: " + e);
    }
    log("");
  }

  // Live-instance sources for classes that can't (or shouldn't) be `new`'d.
  // The constructor check still runs first; `sample` is only consulted when
  // construction fails or returns nothing.
  var classes = [
    // Instantiable value/options classes — `new` works; sample is the fallback.
    { name: "Matrix",                       sample: function () { return new Matrix(); } },
    { name: "RGBColor",                     sample: function () { return new RGBColor(); } },
    { name: "CMYKColor",                    sample: function () { return new CMYKColor(); } },
    { name: "GrayColor",                    sample: function () { return new GrayColor(); } },
    { name: "LabColor",                     sample: function () { return new LabColor(); } },
    { name: "NoColor",                      sample: function () { return new NoColor(); } },
    { name: "SpotColor",                    sample: function () { return new SpotColor(); } },
    { name: "PatternColor",                 sample: function () { return new PatternColor(); } },
    { name: "GradientColor",                sample: function () { return new GradientColor(); } },
    { name: "ExportOptionsJPEG",            sample: function () { return new ExportOptionsJPEG(); } },
    { name: "ExportOptionsPNG8",            sample: function () { return new ExportOptionsPNG8(); } },
    { name: "ExportOptionsPNG24",           sample: function () { return new ExportOptionsPNG24(); } },
    { name: "ExportOptionsGIF",             sample: function () { return new ExportOptionsGIF(); } },
    { name: "ExportOptionsPhotoshop",       sample: function () { return new ExportOptionsPhotoshop(); } },
    { name: "ExportOptionsSVG",             sample: function () { return new ExportOptionsSVG(); } },
    { name: "ExportOptionsTIFF",            sample: function () { return new ExportOptionsTIFF(); } },
    { name: "ExportOptionsAutoCAD",         sample: function () { return new ExportOptionsAutoCAD(); } },
    { name: "ExportOptionsWebOptimizedSVG", sample: function () { return new ExportOptionsWebOptimizedSVG(); } },
    { name: "OpenOptions",                  sample: function () { return new OpenOptions(); } },
    { name: "FXGSaveOptions",               sample: function () { return new FXGSaveOptions(); } },
    { name: "EPSSaveOptions",               sample: function () { return new EPSSaveOptions(); } },
    { name: "PDFSaveOptions",               sample: function () { return new PDFSaveOptions(); } },
    { name: "IllustratorSaveOptions",       sample: function () { return new IllustratorSaveOptions(); } },
    { name: "PrintOptions",                 sample: function () { return new PrintOptions(); } },
    { name: "PrintPaperOptions",            sample: function () { return new PrintPaperOptions(); } },
    { name: "PrintJobOptions",              sample: function () { return new PrintJobOptions(); } },
    { name: "PrintColorSeparationOptions",  sample: function () { return new PrintColorSeparationOptions(); } },
    { name: "PrintCoordinateOptions",       sample: function () { return new PrintCoordinateOptions(); } },
    { name: "PrintPageMarksOptions",        sample: function () { return new PrintPageMarksOptions(); } },
    { name: "PrintFontOptions",             sample: function () { return new PrintFontOptions(); } },
    { name: "PrintPostScriptOptions",       sample: function () { return new PrintPostScriptOptions(); } },
    { name: "PrintColorManagementOptions",  sample: function () { return new PrintColorManagementOptions(); } },
    { name: "PrintFlattenerOptions",        sample: function () { return new PrintFlattenerOptions(); } },
    { name: "DocumentPreset",               sample: function () { return new DocumentPreset(); } },
    { name: "ImageCaptureOptions",          sample: function () { return new ImageCaptureOptions(); } },
    { name: "RasterEffectOptions",          sample: function () { return new RasterEffectOptions(); } },
    { name: "RasterizeOptions",             sample: function () { return new RasterizeOptions(); } },
    { name: "TabStopInfo",                  sample: function () { return new TabStopInfo(); } },

    // Classes docs say are `new`-able but the engine refuses — probed via
    // sample-only paths.
    { name: "ExportOptionsFlash",           sample: function () { return null; } },
    { name: "OpenOptionsPhotoshop",         sample: function () { return app.preferences.photoshopFileOptions; } },
    { name: "OpenOptionsPDF",               sample: function () { return app.preferences.PDFFileOptions; } },
    { name: "OpenOptionsAutoCAD",           sample: function () { return app.preferences.AutoCADFileOptions; } },
    { name: "TracingOptions",               sample: function () { return null; } },

    // Singletons / DOM roots.
    { name: "Application",                  sample: function () { return app; } },
    { name: "Preferences",                  sample: function () { return app.preferences; } },

    // Printer family — only available when a printer is configured.
    { name: "Printer", sample: function () {
        var l = (typeof app.getPrinterList === "function") ? app.getPrinterList() : null;
        return (l && l.length) ? l[0] : null;
      }, note: "no printer configured" },
    { name: "PrinterInfo", sample: function () {
        var l = (typeof app.getPrinterList === "function") ? app.getPrinterList() : null;
        return (l && l.length) ? l[0].printerInfo : null;
      }, note: "no printer configured" },
    { name: "Paper", sample: function () {
        var l = (typeof app.getPrinterList === "function") ? app.getPrinterList() : null;
        var papers = l && l.length && l[0].printerInfo && l[0].printerInfo.paperList;
        return (papers && papers.length) ? papers[0] : null;
      }, note: "no printer configured" },
    { name: "PaperInfo", sample: function () {
        var l = (typeof app.getPrinterList === "function") ? app.getPrinterList() : null;
        var papers = l && l.length && l[0].printerInfo && l[0].printerInfo.paperList;
        return (papers && papers.length) ? papers[0].paperInfo : null;
      }, note: "no printer configured" },
    { name: "Ink", sample: function () {
        var l = (typeof app.getPrinterList === "function") ? app.getPrinterList() : null;
        var inks = l && l.length && l[0].printerInfo && l[0].printerInfo.inkList;
        return (inks && inks.length) ? inks[0] : null;
      }, note: "no printer configured" },
    { name: "InkInfo", sample: function () {
        var l = (typeof app.getPrinterList === "function") ? app.getPrinterList() : null;
        var inks = l && l.length && l[0].printerInfo && l[0].printerInfo.inkList;
        return (inks && inks.length) ? inks[0].inkInfo : null;
      }, note: "no printer configured" }
  ];

  // Document-scoped classes: only probable when a document is open.
  if (app.documents && app.documents.length > 0) {
    var doc = app.activeDocument;
    var first = function (coll) { return (coll && coll.length) ? coll[0] : null; };

    classes.push({ name: "Document",         sample: function () { return doc; } });
    classes.push({ name: "Documents",        sample: function () { return app.documents; } });
    classes.push({ name: "Layer",            sample: function () { return first(doc.layers); } });
    classes.push({ name: "Layers",           sample: function () { return doc.layers; } });
    classes.push({ name: "Artboard",         sample: function () { return first(doc.artboards); } });
    classes.push({ name: "Artboards",        sample: function () { return doc.artboards; } });
    classes.push({ name: "View",             sample: function () { return first(doc.views); } });
    classes.push({ name: "Views",            sample: function () { return doc.views; } });
    classes.push({ name: "Swatch",           sample: function () { return first(doc.swatches); } });
    classes.push({ name: "SwatchGroup",      sample: function () { return first(doc.swatchGroups); } });
    classes.push({ name: "Spot",             sample: function () { return first(doc.spots); } });
    classes.push({ name: "Gradient",         sample: function () { return first(doc.gradients); } });
    classes.push({ name: "GradientStop",     sample: function () {
      return first(doc.gradients) ? first(first(doc.gradients).gradientStops) : null;
    } });
    classes.push({ name: "Pattern",          sample: function () { return first(doc.patterns); } });
    classes.push({ name: "Symbol",           sample: function () { return first(doc.symbols); } });
    classes.push({ name: "Brush",            sample: function () { return first(doc.brushes); } });
    classes.push({ name: "ArtStyle",         sample: function () { return first(doc.artStyles); } });
    classes.push({ name: "TextFont",         sample: function () { return first(app.textFonts); } });
    classes.push({ name: "PageItem",         sample: function () { return first(doc.pageItems); } });
    classes.push({ name: "PathItem",         sample: function () { return first(doc.pathItems); } });
    classes.push({ name: "PathPoint",        sample: function () {
      return first(doc.pathItems) ? first(first(doc.pathItems).pathPoints) : null;
    } });
    classes.push({ name: "CompoundPathItem", sample: function () { return first(doc.compoundPathItems); } });
    classes.push({ name: "GroupItem",        sample: function () { return first(doc.groupItems); } });
    classes.push({ name: "CharacterStyle",   sample: function () { return first(doc.characterStyles); } });
    classes.push({ name: "ParagraphStyle",   sample: function () { return first(doc.paragraphStyles); } });
  }

  log("Illustrator reflect probe");
  log("app:        " + app.name + " " + app.version);
  log("generated:  " + new Date());
  log("");
  log("Decisions per class:");
  log("  constructor: public   → keep default TS constructor");
  log("  constructor: private  → typedef needs `private constructor()`");
  log("  props / methods       → instance API surface (goes in class body)");
  log("");

  for (var i = 0; i < classes.length; i++) probe(classes[i]);

  var f = new File(Folder.desktop + "/ai-reflect-report.txt");
  f.encoding = "UTF-8";
  f.open("w");
  f.write(out.join("\n"));
  f.close();

  alert("Probe complete.\n\n" + classes.length + " classes.\nReport: " + f.fsName);
})();
```
</details>